### PR TITLE
Increased maximum length of SonarQube server configuration items

### DIFF
--- a/src/main/java/org/sonarlint/intellij/config/global/SonarQubeServerEditor.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/SonarQubeServerEditor.java
@@ -58,7 +58,7 @@ import org.sonarsource.sonarlint.core.client.api.connected.ValidationResult;
 
 public class SonarQubeServerEditor extends DialogWrapper {
   private static final Logger LOGGER = Logger.getInstance(SonarQubeServerEditor.class);
-  private static final int MAX_LENGTH = 50;
+  private static final int NAME_MAX_LENGTH = 50;
   private static final int TEXT_COLUMNS = 30;
   private static final String AUTH_PASSWORD = "Password";
   private static final String AUTH_TOKEN = "Token";
@@ -145,7 +145,7 @@ public class SonarQubeServerEditor extends DialogWrapper {
     nameLabel = new JBLabel("Name:", SwingConstants.RIGHT);
     nameLabel.setDisplayedMnemonic('N');
     nameText = new JBTextField();
-    nameText.setDocument(new LengthRestrictedDocument(MAX_LENGTH));
+    nameText.setDocument(new LengthRestrictedDocument(NAME_MAX_LENGTH));
     nameText.setText(server.getName());
     if(!isCreating) {
       nameText.setFont(nameText.getFont().deriveFont(Font.BOLD));

--- a/src/main/java/org/sonarlint/intellij/config/global/SonarQubeServerEditor.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/SonarQubeServerEditor.java
@@ -46,6 +46,8 @@ import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
+import javax.swing.text.PlainDocument;
+
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.sonarlint.intellij.core.ConnectionTestTask;
@@ -154,7 +156,7 @@ public class SonarQubeServerEditor extends DialogWrapper {
     urlLabel = new JBLabel("Server URL:", SwingConstants.RIGHT);
     urlLabel.setDisplayedMnemonic('U');
     urlText = new JBTextField();
-    urlText.setDocument(new LengthRestrictedDocument(MAX_LENGTH));
+    urlText.setDocument(new PlainDocument());
     urlText.setText(server.getHostUrl());
     urlText.getEmptyText().setText("Example: http://localhost:9000");
     urlLabel.setLabelFor(urlText);
@@ -168,21 +170,21 @@ public class SonarQubeServerEditor extends DialogWrapper {
     loginLabel = new JBLabel("Login:", SwingConstants.RIGHT);
     loginLabel.setDisplayedMnemonic('L');
     loginText = new JBTextField();
-    loginText.setDocument(new LengthRestrictedDocument(MAX_LENGTH));
+    loginText.setDocument(new PlainDocument());
     loginText.setText(server.getLogin());
     loginText.getEmptyText().setText("");
     loginLabel.setLabelFor(loginText);
 
     passwordLabel = new JBLabel("Password:", SwingConstants.RIGHT);
     passwordText = new JBPasswordField();
-    passwordText.setDocument(new LengthRestrictedDocument(MAX_LENGTH));
+    passwordText.setDocument(new PlainDocument());
     passwordText.setText(server.getPassword());
     passwordText.getEmptyText().setText("");
     passwordLabel.setLabelFor(passwordText);
 
     tokenLabel = new JBLabel("Token:", SwingConstants.RIGHT);
     tokenText = new JBPasswordField();
-    tokenText.setDocument(new LengthRestrictedDocument(MAX_LENGTH));
+    tokenText.setDocument(new PlainDocument());
     tokenText.setColumns(TEXT_COLUMNS);
     tokenText.setText(server.getToken());
     tokenText.getEmptyText().setText("");


### PR DESCRIPTION
I tested the new version 2.0.0 and discovered that with that version we are unable to use our SonarQube in the company due to the restriction of the Server URL to 50 characters.

Therefore this pull-request to increase this. What I asked myself is the reason to limit this setting to 50. Is this a limitation of the core library?