### PR TITLE
Set read timeout when connecting to SonarQube server to 30 seconds to…

### DIFF
--- a/src/main/java/org/sonarlint/intellij/util/SonarLintUtils.java
+++ b/src/main/java/org/sonarlint/intellij/util/SonarLintUtils.java
@@ -56,6 +56,7 @@ import org.sonarsource.sonarlint.core.client.api.connected.ServerConfiguration;
 public class SonarLintUtils {
 
   private static final Logger LOG = Logger.getInstance(SonarLintUtils.class);
+  static final int DEFAULT_READ_TIMEOUT = 30000;
 
   private SonarLintUtils() {
     // Utility class
@@ -247,7 +248,7 @@ public class SonarLintUtils {
     ServerConfiguration.Builder serverConfigBuilder = ServerConfiguration.builder()
       .userAgent("SonarLint IntelliJ " + sonarlint.getVersion())
       .connectTimeoutMilliseconds(5000)
-      .readTimeoutMilliseconds(5000)
+      .readTimeoutMilliseconds(DEFAULT_READ_TIMEOUT)
       .url(server.getHostUrl());
     if (server.getToken() != null) {
       serverConfigBuilder.token(server.getToken());

--- a/src/test/java/org/sonarlint/intellij/util/SonarLintUtilsTest.java
+++ b/src/test/java/org/sonarlint/intellij/util/SonarLintUtilsTest.java
@@ -34,6 +34,7 @@ import org.sonarsource.sonarlint.core.client.api.connected.ServerConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.sonarlint.intellij.util.SonarLintUtils.DEFAULT_READ_TIMEOUT;
 
 public class SonarLintUtilsTest extends SonarTest {
   private VirtualFile testFile;
@@ -106,7 +107,7 @@ public class SonarLintUtilsTest extends SonarTest {
     assertThat(config.getLogin()).isEqualTo(server.getToken());
     assertThat(config.getPassword()).isNull();
     assertThat(config.getConnectTimeoutMs()).isEqualTo(5000);
-    assertThat(config.getReadTimeoutMs()).isEqualTo(5000);
+    assertThat(config.getReadTimeoutMs()).isEqualTo(DEFAULT_READ_TIMEOUT);
     assertThat(config.getUserAgent()).contains("SonarLint");
     assertThat(config.getUrl()).isEqualTo(server.getHostUrl());
   }


### PR DESCRIPTION
… support slow response time from api/plugins/installed endpoint

Our SonarQube installation uses for some reason about 20 seconds to respond to a request to http://sonar.eva.lokal/api/plugins/installed.   Increasing the default timeout makes it possible for us to bind to our SonarQube server and fetch settings.