### PR TITLE
Read timeout as a server configuration value

### DIFF
--- a/src/main/java/org/sonarlint/intellij/config/global/SonarQubeServer.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/SonarQubeServer.java
@@ -35,6 +35,7 @@ public class SonarQubeServer {
   private String login;
   private String password;
   private boolean enableProxy;
+  private String timeout;
 
   public SonarQubeServer() {
     // no args
@@ -152,4 +153,11 @@ public class SonarQubeServer {
     return name;
   }
 
+  public String getTimeout() {
+      return timeout;
+  }
+
+  public void setTimeout(String timeout) {
+    this.timeout = timeout;
+  }
 }

--- a/src/main/java/org/sonarlint/intellij/config/global/SonarQubeServerEditor.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/SonarQubeServerEditor.java
@@ -92,8 +92,11 @@ public class SonarQubeServerEditor extends DialogWrapper {
   private JButton proxySettingsButton;
 
   protected JButton testButton;
+    
+  private JBLabel timeoutLabel;
+  private JBTextField timeoutText;
 
-  protected SonarQubeServerEditor(JComponent parent, List<SonarQubeServer> serverList, SonarQubeServer server, boolean isCreating) {
+    protected SonarQubeServerEditor(JComponent parent, List<SonarQubeServer> serverList, SonarQubeServer server, boolean isCreating) {
     super(parent, true);
     this.isCreating = isCreating;
     this.server = server;
@@ -136,6 +139,10 @@ public class SonarQubeServerEditor extends DialogWrapper {
 
     if (StringUtils.isEmpty(urlText.getText())) {
       return new ValidationInfo("Servers must be configured with a host URL", urlText);
+    }
+
+    if (!StringUtils.isNumeric(timeoutText.getText())) {
+      return new ValidationInfo("Timeout must be a value in milliseconds", timeoutText);
     }
 
     return null;
@@ -202,6 +209,13 @@ public class SonarQubeServerEditor extends DialogWrapper {
     enableProxy.setMnemonic('y');
 
     enableProxy.setEnabled(HttpConfigurable.getInstance().USE_HTTP_PROXY);
+
+    timeoutLabel = new JBLabel("Read timeout:", SwingConstants.RIGHT);
+    timeoutText = new JBTextField();
+    timeoutText.setDocument(new PlainDocument());
+    timeoutText.setText(server.getTimeout());
+    timeoutText.getEmptyText().setText("");
+    timeoutLabel.setLabelFor(timeoutText);
 
     testButton = new JButton("Test connection");
     testButton.setFont(testButton.getFont().deriveFont(Font.BOLD));
@@ -287,6 +301,7 @@ public class SonarQubeServerEditor extends DialogWrapper {
       .addLabeledComponentWithButton(tokenLabel, tokenText, tokenButton)
       .addLabeledComponent(loginLabel, loginText, true)
       .addLabeledComponent(passwordLabel, passwordText, true)
+      .addLabeledComponent(timeoutLabel, timeoutText, true)
       .addLabeledComponent(enableProxy, proxySettingsButton, false)
       .addSeparator(5);
 
@@ -333,6 +348,7 @@ public class SonarQubeServerEditor extends DialogWrapper {
       server.setPassword(new String(passwordText.getPassword()));
     }
     server.setEnableProxy(enableProxy.isSelected());
+    server.setTimeout(timeoutText.getText().trim());
   }
 
   private void generateToken() {

--- a/src/main/java/org/sonarlint/intellij/util/SonarLintUtils.java
+++ b/src/main/java/org/sonarlint/intellij/util/SonarLintUtils.java
@@ -248,7 +248,7 @@ public class SonarLintUtils {
     ServerConfiguration.Builder serverConfigBuilder = ServerConfiguration.builder()
       .userAgent("SonarLint IntelliJ " + sonarlint.getVersion())
       .connectTimeoutMilliseconds(5000)
-      .readTimeoutMilliseconds(DEFAULT_READ_TIMEOUT)
+      .readTimeoutMilliseconds(StringUtil.isEmptyOrSpaces(server.getTimeout()) ? DEFAULT_READ_TIMEOUT : new Integer(server.getTimeout()))
       .url(server.getHostUrl());
     if (server.getToken() != null) {
       serverConfigBuilder.token(server.getToken());

--- a/src/main/java/org/sonarlint/intellij/util/SonarLintUtils.java
+++ b/src/main/java/org/sonarlint/intellij/util/SonarLintUtils.java
@@ -56,6 +56,7 @@ import org.sonarsource.sonarlint.core.client.api.connected.ServerConfiguration;
 public class SonarLintUtils {
 
   private static final Logger LOG = Logger.getInstance(SonarLintUtils.class);
+  static final int DEFAULT_READ_TIMEOUT = 30000;
 
   private SonarLintUtils() {
     // Utility class
@@ -247,7 +248,7 @@ public class SonarLintUtils {
     ServerConfiguration.Builder serverConfigBuilder = ServerConfiguration.builder()
       .userAgent("SonarLint IntelliJ " + sonarlint.getVersion())
       .connectTimeoutMilliseconds(5000)
-      .readTimeoutMilliseconds(5000)
+      .readTimeoutMilliseconds(DEFAULT_READ_TIMEOUT)
       .url(server.getHostUrl());
     if (server.getToken() != null) {
       serverConfigBuilder.token(server.getToken());

--- a/src/test/java/org/sonarlint/intellij/util/SonarLintUtilsTest.java
+++ b/src/test/java/org/sonarlint/intellij/util/SonarLintUtilsTest.java
@@ -34,6 +34,7 @@ import org.sonarsource.sonarlint.core.client.api.connected.ServerConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.sonarlint.intellij.util.SonarLintUtils.DEFAULT_READ_TIMEOUT;
 
 public class SonarLintUtilsTest extends SonarTest {
   private VirtualFile testFile;
@@ -106,7 +107,7 @@ public class SonarLintUtilsTest extends SonarTest {
     assertThat(config.getLogin()).isEqualTo(server.getToken());
     assertThat(config.getPassword()).isNull();
     assertThat(config.getConnectTimeoutMs()).isEqualTo(5000);
-    assertThat(config.getReadTimeoutMs()).isEqualTo(5000);
+    assertThat(config.getReadTimeoutMs()).isEqualTo(DEFAULT_READ_TIMEOUT);
     assertThat(config.getUserAgent()).contains("SonarLint");
     assertThat(config.getUrl()).isEqualTo(server.getHostUrl());
   }

--- a/src/test/java/org/sonarlint/intellij/util/SonarLintUtilsTest.java
+++ b/src/test/java/org/sonarlint/intellij/util/SonarLintUtilsTest.java
@@ -126,4 +126,21 @@ public class SonarLintUtilsTest extends SonarTest {
     assertThat(config.getLogin()).isEqualTo(server.getLogin());
     assertThat(config.getPassword()).isEqualTo(server.getPassword());
   }
+
+  @Test
+  public void testServerConfigurationTimeout() {
+    SonarApplication app = mock(SonarApplication.class);
+    when(app.getVersion()).thenReturn("1.0");
+    super.register(ApplicationManager.getApplication(), SonarApplication.class, app);
+
+    SonarQubeServer server = new SonarQubeServer();
+    server.setHostUrl("http://myhost");
+    server.setLogin("token");
+    server.setPassword("pass");
+    server.setTimeout("1");
+    
+    ServerConfiguration config = SonarLintUtils.getServerConfiguration(server);
+    
+    assertThat(config.getReadTimeoutMs()).isEqualTo(new Integer(server.getTimeout()));
+  }
 }


### PR DESCRIPTION
Added possibility to configure read timeout on server configuration in case it is needed..  default value is used if not set.