### PR TITLE
SLI-93: Replace getModules by Extension Point API.

### DIFF
--- a/src/main/java/org/sonarlint/intellij/analysis/SonarLintAnalyzer.java
+++ b/src/main/java/org/sonarlint/intellij/analysis/SonarLintAnalyzer.java
@@ -19,6 +19,7 @@
  */
 package org.sonarlint.intellij.analysis;
 
+import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ContentEntry;
@@ -45,6 +46,11 @@ import java.util.List;
 import java.util.Map;
 
 public class SonarLintAnalyzer {
+
+  // Name is constructed from plugin-id.extension-point-name
+  private static ExtensionPointName<AnalysisConfigurator> EP_NAME
+    = ExtensionPointName.create("org.sonarlint.idea.AnalysisConfiguration");
+
   public AnalysisResults analyzeModule(Module module, Collection<VirtualFile> filesToAnalyze, IssueListener listener) {
     Project p = module.getProject();
     SonarLintConsole console = SonarLintConsole.get(p);
@@ -52,7 +58,7 @@ public class SonarLintAnalyzer {
 
     // Configure plugin properties. Nothing might be done if there is no configurator available for the extensions loaded in runtime.
     Map<String, String> pluginProps = new HashMap<>();
-    AnalysisConfigurator[] analysisConfigurators = module.getComponents(AnalysisConfigurator.class);
+    AnalysisConfigurator[] analysisConfigurators = EP_NAME.getExtensions();
     if (analysisConfigurators.length > 0) {
       for (AnalysisConfigurator config : analysisConfigurators) {
         console.debug("Configuring analysis with " + config.getClass().getName());

--- a/src/main/resources/META-INF/plugin-java.xml
+++ b/src/main/resources/META-INF/plugin-java.xml
@@ -24,9 +24,10 @@
     <component>
         <implementation-class>org.sonarlint.intellij.trigger.MakeTrigger</implementation-class>
     </component>
-      <component>
-          <implementation-class>org.sonarlint.intellij.analysis.JavaAnalysisConfigurator</implementation-class>
-          <interface-class>org.sonarlint.intellij.analysis.AnalysisConfigurator</interface-class>
-      </component>
   </project-components>
+
+  <extensions defaultExtensionNs="org.sonarlint.idea">
+    <AnalysisConfiguration implementation="org.sonarlint.intellij.analysis.JavaAnalysisConfigurator" />
+  </extensions>
+
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -117,6 +117,10 @@
         <colorSettingsPage implementation="org.sonarlint.intellij.config.SonarLintColorSettingsPage"/>
     </extensions>
 
+    <extensionPoints>
+        <extensionPoint name="AnalysisConfiguration" interface="org.sonarlint.intellij.analysis.AnalysisConfigurator" />
+    </extensionPoints>
+
     <actions>
         <group id="SonarLint.logtoolwindow" text="SonarLint" popup="true"/>
         <group id="SonarLint.issuestoolwindow" text="SonarLint" popup="true"/>


### PR DESCRIPTION
The JavaAnalysisConfigurator was never detected which caused that the
bytecode would NOT be supplied to the Sonar Java plugin which causes
more FPs and FNs to occur.