### PR TITLE
Add mnemonics to the Review dialog

### DIFF
--- a/src/main/java/org/sonarlint/intellij/trigger/SonarLintCheckinHandler.java
+++ b/src/main/java/org/sonarlint/intellij/trigger/SonarLintCheckinHandler.java
@@ -166,8 +166,8 @@ public class SonarLintCheckinHandler extends CheckinHandler {
     final int answer = Messages.showYesNoCancelDialog(project,
       resultStr,
       "SonarLint Analysis Results",
-      "Review Issues",
-      "Commit Anyway",
+      "&Review Issues",
+      "Comm&it Anyway",
       "Close",
       UIUtil.getWarningIcon());
 


### PR DESCRIPTION
The current Review dialog cannot be accessed using the keyboard.
This commit introduces **mnemonics**, the same as found in the Intellij Commit/Review dialog.

Screenshot of the change:

![20170725_selection_003](https://user-images.githubusercontent.com/365778/28559629-96cfe286-7117-11e7-8616-8955656e258f.png)

Default Intellij commit dialog:

![20170725_selection_002](https://user-images.githubusercontent.com/365778/28559634-9c2b0fd0-7117-11e7-8144-079e06a46488.png)
