### PR TITLE
Added settings to filter issues by severity and type

### DIFF
--- a/src/main/java/org/sonarlint/intellij/config/global/SonarLintGlobalOptionsPanel.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/SonarLintGlobalOptionsPanel.java
@@ -19,17 +19,34 @@
  */
 package org.sonarlint.intellij.config.global;
 
+import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.VerticalFlowLayout;
+import com.intellij.ui.IdeBorderFactory;
+import com.intellij.util.ui.JBInsets;
+import com.intellij.util.ui.JBUI;
+
 import java.awt.BorderLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+
 import javax.swing.BorderFactory;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import org.sonarlint.intellij.config.ConfigurationPanel;
+
+import org.sonarlint.intellij.util.SonarLintSeverity;
 
 public class SonarLintGlobalOptionsPanel implements ConfigurationPanel<SonarLintGlobalSettings> {
   private JPanel rootPane;
   private JCheckBox autoTrigger;
+
+  private ComboBox<SonarLintSeverity> issueSeverity;
+
+  private JCheckBox issueTypeBug;
+  private JCheckBox issueTypeCodeSmell;
+  private JCheckBox issueTypeVulnerability;
 
   @Override
   public JComponent getComponent() {
@@ -37,6 +54,7 @@ public class SonarLintGlobalOptionsPanel implements ConfigurationPanel<SonarLint
 
       rootPane = new JPanel(new BorderLayout());
       rootPane.add(createTopPanel(), BorderLayout.NORTH);
+      rootPane.add(createIssueFilterPanel(), BorderLayout.WEST);
     }
 
     return rootPane;
@@ -52,22 +70,75 @@ public class SonarLintGlobalOptionsPanel implements ConfigurationPanel<SonarLint
     return tickOptions;
   }
 
+  private JPanel createIssueFilterPanel() {
+    JPanel issueFilterPanel = new JPanel(new GridBagLayout());
+    issueFilterPanel.setBorder(IdeBorderFactory.createTitledBorder("Issue filters"));
+    JBInsets insets = JBUI.insets(0, 0, 4, 4);
+
+    createIssueSeverityFilter(issueFilterPanel, insets);
+    createIssueTypeFilter(issueFilterPanel, insets);
+
+    return issueFilterPanel;
+  }
+
+  private void createIssueSeverityFilter(JPanel issueFilterPanel, JBInsets insets) {
+    JLabel issueSeverityLabel = new JLabel("Minimum severity:");
+    issueSeverity = new ComboBox<>(SonarLintSeverity.values());
+
+    issueFilterPanel.add(issueSeverityLabel, new GridBagConstraints(0, 0, 1, 1, 0, 0, GridBagConstraints.LINE_START, 0, insets, 0, 0));
+    issueFilterPanel.add(issueSeverity, new GridBagConstraints(1, 0, 3, 1, 0, 0, GridBagConstraints.LINE_START, 0, insets, 0, 0));
+  }
+
+  private void createIssueTypeFilter(JPanel issueFilterPanel, JBInsets insets) {
+    JLabel issueTypeLabel = new JLabel("Display issue types:");
+    issueTypeBug = new JCheckBox("Bug");
+    issueTypeBug.setFocusable(false);
+    issueTypeCodeSmell = new JCheckBox("Code smell");
+    issueTypeCodeSmell.setFocusable(false);
+    issueTypeVulnerability = new JCheckBox("Vulnerability");
+    issueTypeVulnerability.setFocusable(false);
+
+    issueFilterPanel.add(issueTypeLabel, new GridBagConstraints(0, 1, 1, 1, 0, 0, GridBagConstraints.LINE_START, 0, insets, 0, 0));
+    issueFilterPanel.add(issueTypeBug, new GridBagConstraints(1, 1, 1, 1, 0, 0, GridBagConstraints.LINE_START, 0, insets, 0, 0));
+    issueFilterPanel.add(issueTypeCodeSmell, new GridBagConstraints(2, 1, 1, 1, 0, 0, GridBagConstraints.LINE_START, 0, insets, 0, 0));
+    issueFilterPanel.add(issueTypeVulnerability, new GridBagConstraints(3, 1, 1, 1, 0, 0, GridBagConstraints.LINE_START, 0, insets, 0, 0));
+  }
+
   @Override
   public boolean isModified(SonarLintGlobalSettings model) {
     getComponent();
-    return model.isAutoTrigger() != autoTrigger.isSelected();
+
+    boolean issueTypeFilterChanged = model.isIssueTypeBug() != issueTypeBug.isSelected()
+      || model.isIssueTypeCodeSmell() != issueTypeCodeSmell.isSelected()
+      || model.isIssueTypeVulnerability() != issueTypeVulnerability.isSelected();
+
+    return model.isAutoTrigger() != autoTrigger.isSelected()
+      || model.getIssueSeverity() != issueSeverity.getSelectedItem()
+      || issueTypeFilterChanged;
   }
 
   @Override
   public void load(SonarLintGlobalSettings model) {
     getComponent();
     autoTrigger.setSelected(model.isAutoTrigger());
+
+    issueSeverity.setSelectedItem(model.getIssueSeverity());
+
+    issueTypeBug.setSelected(model.isIssueTypeBug());
+    issueTypeCodeSmell.setSelected(model.isIssueTypeCodeSmell());
+    issueTypeVulnerability.setSelected(model.isIssueTypeVulnerability());
   }
 
   @Override
   public void save(SonarLintGlobalSettings model) {
     getComponent();
     model.setAutoTrigger(autoTrigger.isSelected());
+
+    model.setIssueSeverity((SonarLintSeverity) issueSeverity.getSelectedItem());
+
+    model.setIssueTypeBug(issueTypeBug.isSelected());
+    model.setIssueTypeCodeSmell(issueTypeCodeSmell.isSelected());
+    model.setIssueTypeVulnerability(issueTypeVulnerability.isSelected());
   }
 }
 

--- a/src/main/java/org/sonarlint/intellij/config/global/SonarLintGlobalSettings.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/SonarLintGlobalSettings.java
@@ -37,12 +37,20 @@ import java.util.stream.Collectors;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.sonarlint.intellij.util.SonarLintBundle;
+import org.sonarlint.intellij.util.SonarLintSeverity;
 import org.sonarlint.intellij.util.SonarLintUtils;
 
 @State(name = "SonarLintGlobalSettings", storages = {@Storage(id = "sonarlint", file = StoragePathMacros.APP_CONFIG + "/sonarlint.xml")})
 public final class SonarLintGlobalSettings extends ApplicationComponent.Adapter implements PersistentStateComponent<SonarLintGlobalSettings>, ExportableApplicationComponent {
 
   private boolean autoTrigger = true;
+
+  private SonarLintSeverity issueSeverity = SonarLintSeverity.INFO;
+
+  private boolean issueTypeBug = true;
+  private boolean issueTypeCodeSmell = true;
+  private boolean issueTypeVulnerability = true;
+
   private List<SonarQubeServer> servers = new LinkedList<>();
   private List<String> fileExclusions = new LinkedList<>();
 
@@ -85,6 +93,38 @@ public final class SonarLintGlobalSettings extends ApplicationComponent.Adapter 
 
   public void setAutoTrigger(boolean autoTrigger) {
     this.autoTrigger = autoTrigger;
+  }
+
+  public SonarLintSeverity getIssueSeverity() {
+    return issueSeverity;
+  }
+
+  public void setIssueSeverity(SonarLintSeverity issueSeverity) {
+    this.issueSeverity = issueSeverity;
+  }
+
+  public boolean isIssueTypeBug() {
+    return issueTypeBug;
+  }
+
+  public void setIssueTypeBug(boolean issueTypeBug) {
+    this.issueTypeBug = issueTypeBug;
+  }
+
+  public boolean isIssueTypeCodeSmell() {
+    return issueTypeCodeSmell;
+  }
+
+  public void setIssueTypeCodeSmell(boolean issueTypeCodeSmell) {
+    this.issueTypeCodeSmell = issueTypeCodeSmell;
+  }
+
+  public boolean isIssueTypeVulnerability() {
+    return issueTypeVulnerability;
+  }
+
+  public void setIssueTypeVulnerability(boolean issueTypeVulnerability) {
+    this.issueTypeVulnerability = issueTypeVulnerability;
   }
 
   public void setSonarQubeServers(List<SonarQubeServer> servers) {

--- a/src/main/java/org/sonarlint/intellij/issue/IssueProcessor.java
+++ b/src/main/java/org/sonarlint/intellij/issue/IssueProcessor.java
@@ -39,9 +39,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.sonarlint.intellij.analysis.AnalysisCallback;
 import org.sonarlint.intellij.analysis.SonarLintJob;
+import org.sonarlint.intellij.config.global.SonarLintGlobalSettings;
 import org.sonarlint.intellij.core.ServerIssueUpdater;
 import org.sonarlint.intellij.trigger.TriggerType;
 import org.sonarlint.intellij.ui.SonarLintConsole;
+import org.sonarlint.intellij.util.SonarLintSeverity;
 import org.sonarsource.sonarlint.core.client.api.common.analysis.ClientInputFile;
 import org.sonarsource.sonarlint.core.client.api.common.analysis.Issue;
 import org.sonarsource.sonarlint.core.client.api.common.analysis.IssueLocation;
@@ -52,13 +54,16 @@ public class IssueProcessor extends AbstractProjectComponent {
   private final IssueManager manager;
   private final SonarLintConsole console;
   private final ServerIssueUpdater serverIssueUpdater;
+  private final SonarLintGlobalSettings globalSettings;
 
-  public IssueProcessor(Project project, IssueMatcher matcher, IssueManager manager, ServerIssueUpdater serverIssueUpdater) {
+  public IssueProcessor(Project project, IssueMatcher matcher, IssueManager manager, ServerIssueUpdater serverIssueUpdater,
+      SonarLintGlobalSettings globalSettings) {
     super(project);
     this.matcher = matcher;
     this.manager = manager;
     this.console = SonarLintConsole.get(project);
     this.serverIssueUpdater = serverIssueUpdater;
+    this.globalSettings = globalSettings;
   }
 
   public void process(final SonarLintJob job, ProgressIndicator indicator, final Collection<Issue> rawIssues, Collection<ClientInputFile> failedAnalysisFiles) {
@@ -149,6 +154,9 @@ public class IssueProcessor extends AbstractProjectComponent {
         // file is no longer valid (might have been deleted meanwhile) or there has been an error matching an issue in it
         continue;
       }
+      if (ignoreIssueBasedOnSettings(issue)) {
+        continue;
+      }
       try {
         LiveIssue toStore = transformIssue(issue, vFile);
         map.get(vFile).add(toStore);
@@ -161,6 +169,24 @@ public class IssueProcessor extends AbstractProjectComponent {
     }
 
     return map;
+  }
+
+  private boolean ignoreIssueBasedOnSettings(Issue issue) {
+    SonarLintSeverity issueSeverity = globalSettings.getIssueSeverity();
+    if (issueSeverity.compareTo(SonarLintSeverity.byName(issue.getSeverity())) < 0) {
+      // ignore issues with severity lower than configured
+      return true;
+    }
+
+    String issueType = issue.getType();
+    if (("BUG".equals(issueType) && !globalSettings.isIssueTypeBug())
+        || ("CODE_SMELL".equals(issueType) && !globalSettings.isIssueTypeCodeSmell())
+        || ("VULNERABILITY".equals(issueType) && !globalSettings.isIssueTypeVulnerability())) {
+      // ignore issues with disabled type
+      return true;
+    }
+
+    return false;
   }
 
   private LiveIssue transformIssue(Issue issue, VirtualFile vFile) throws IssueMatcher.NoMatchException {


### PR DESCRIPTION
Severity filtering might be useful when working on old projects, as there's usually quite a lot of issues, so it might be useful to filter out only the most critical ones and not be flooded with the low severity ones.