### PR TITLE
Extend read timeout to 10 minutes

### DIFF
--- a/src/main/java/org/sonarlint/intellij/util/SonarLintUtils.java
+++ b/src/main/java/org/sonarlint/intellij/util/SonarLintUtils.java
@@ -66,7 +66,7 @@ public class SonarLintUtils {
 
   private static final Logger LOG = Logger.getInstance(SonarLintUtils.class);
   static final int CONNECTION_TIMEOUT_MS = 30_000;
-  static final int READ_TIMEOUT_MS = 2 * 60_000;
+  static final int READ_TIMEOUT_MS = 10 * 60_000;
   static final String PATH_SEPARATOR_PATTERN = Pattern.quote(File.separator);
   private static final String[] SONARCLOUD_ALIAS = {"https://sonarqube.com", "https://www.sonarqube.com",
     "https://www.sonarcloud.io", "https://sonarcloud.io"};


### PR DESCRIPTION
For slow SonarQube server and big projects (we have around 4 mil. lines of code) SonarLint times out. Can we extend timeout to 10 minutes?