### PR TITLE
Made RulePanel allow horizontal scrolling

### DIFF
--- a/src/main/java/org/sonarlint/intellij/ui/AbstractIssuesPanel.java
+++ b/src/main/java/org/sonarlint/intellij/ui/AbstractIssuesPanel.java
@@ -98,7 +98,7 @@ abstract class AbstractIssuesPanel extends SimpleToolWindowPanel implements Occu
     JScrollPane scrollableRulePanel = ScrollPaneFactory.createScrollPane(
       rulePanel.getPanel(),
       ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
-      ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+      ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
     scrollableRulePanel.getVerticalScrollBar().setUnitIncrement(10);
 
     detailsTab = new JBTabbedPane();


### PR DESCRIPTION
For some reason horizontal scrolling was disabled in the Rule Panel. I enabled it as some rules have quite extensive text that goes beyond the window borders. Having word wrap on HTML Editor Panes seems to be more complicated.