### PR TITLE
Expand All button in Report Panel

### DIFF
--- a/src/main/java/org/sonarlint/intellij/ui/SonarLintAnalysisResultsPanel.java
+++ b/src/main/java/org/sonarlint/intellij/ui/SonarLintAnalysisResultsPanel.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.tools.SimpleActionGroup;
 import com.intellij.ui.ScrollPaneFactory;
+import com.intellij.ui.treeStructure.actions.ExpandAllAction;
 import com.intellij.util.messages.MessageBusConnection;
 import com.intellij.util.ui.tree.TreeUtil;
 import java.awt.BorderLayout;
@@ -56,7 +57,7 @@ public class SonarLintAnalysisResultsPanel extends AbstractIssuesPanel {
     subscribeToEvents();
   }
 
-  private static SimpleActionGroup createActionGroup() {
+  private SimpleActionGroup createActionGroup() {
     SonarLintActions sonarLintActions = SonarLintActions.getInstance();
     SimpleActionGroup actionGroup = new SimpleActionGroup();
     actionGroup.add(sonarLintActions.analyzeChangedFiles());
@@ -64,6 +65,7 @@ public class SonarLintAnalysisResultsPanel extends AbstractIssuesPanel {
     actionGroup.add(sonarLintActions.cancelAnalysis());
     actionGroup.add(sonarLintActions.configure());
     actionGroup.add(sonarLintActions.clearResults());
+    actionGroup.add(new ExpandAllAction(tree));
     return actionGroup;
   }
 


### PR DESCRIPTION
Sometimes we need to expand all even though the number of issues is more than 30.

![image](https://user-images.githubusercontent.com/1861745/49905929-20effd00-feb3-11e8-9aeb-dda2c2761fef.png)
