### PR TITLE
toLowerCase Locale bug fix

### DIFF
--- a/src/main/java/org/sonarlint/intellij/ui/nodes/IssueNode.java
+++ b/src/main/java/org/sonarlint/intellij/ui/nodes/IssueNode.java
@@ -34,6 +34,8 @@ import org.sonarlint.intellij.util.CompoundIcon;
 import org.sonarlint.intellij.util.SonarLintUtils;
 import org.sonarsource.sonarlint.core.client.api.util.DateUtils;
 
+import java.util.Locale;
+
 import static com.intellij.ui.SimpleTextAttributes.STYLE_SMALLER;
 
 public class IssueNode extends AbstractNode {
@@ -47,11 +49,11 @@ public class IssueNode extends AbstractNode {
   }
 
   @Override public void render(TreeCellRenderer renderer) {
-    String severity = StringUtil.capitalize(StringUtil.toLowerCase(issue.getSeverity()));
+    String severity = StringUtil.capitalize(issue.getSeverity().toLowerCase(Locale.ENGLISH));
     String type = issue.getType();
 
     if (type != null) {
-      String typeStr = StringUtil.toLowerCase(type.replace('_', ' '));
+      String typeStr = type.replace('_', ' ').toLowerCase(Locale.ENGLISH);
       renderer.setIconToolTip(severity + " " + typeStr);
       int gap = JBUI.isHiDPI() ? 8 : 4;
       setIcon(renderer, new CompoundIcon(CompoundIcon.Axis.X_AXIS, gap, SonarLintIcons.type12(type), SonarLintIcons.severity12(severity)));


### PR DESCRIPTION
This commit fixes the bug that mentioned here:
[https://stackoverflow.com/questions/54946147/intellij-idea-sonarlint-icon-can-not-found](https://stackoverflow.com/questions/54946147/intellij-idea-sonarlint-icon-can-not-found)

StringUtil.toLowerCase uses defaultLocale. If default locale is TURKISH or something, icon become mınor12.png ( lowered I with doteless )

`
Icon cannot be found in '/images/severity/mınor12.png', aClass='class icons.SonarLintIcons'
java.lang.Throwable: Icon cannot be found in '/images/severity/mınor12.png', aClass='class icons.SonarLintIcons'
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:136)
	at com.intellij.openapi.util.IconLoader.getIcon(IconLoader.java:157)
	at com.intellij.openapi.util.IconLoader.getIcon(IconLoader.java:118)
	at icons.SonarLintIcons.severity(SonarLintIcons.java:56)
	at icons.SonarLintIcons.severity12(SonarLintIcons.java:47)
	at org.sonarlint.intellij.ui.nodes.IssueNode.render(IssueNode.java:57)
`