### PR TITLE
Try new API to get project base path, fix NPE in LightEdit mode

### DIFF
--- a/src/main/java/org/sonarlint/intellij/issue/persistence/IssuePersistence.java
+++ b/src/main/java/org/sonarlint/intellij/issue/persistence/IssuePersistence.java
@@ -85,7 +85,7 @@ public class IssuePersistence extends AbstractProjectComponent {
   }
 
   private Path getBasePath() {
-    Path ideaDir = new File(myProject.getBaseDir().getPath(), Project.DIRECTORY_STORE_FOLDER).toPath();
+    Path ideaDir = new File(myProject.getBasePath(), Project.DIRECTORY_STORE_FOLDER).toPath();
     return ideaDir.resolve("sonarlint").resolve("issuestore");
   }
 


### PR DESCRIPTION
Tested with IDEA Community 2018.1, 2019.2 and WebStorm 2020.1 (in both full and "LightEdit" mode for the last one).

Deprecated method `Project.getBaseDir()` returns `null` in LightEdit mode, resulting in NPE with SonarLint < 4.6