### PR TITLE
Remove null check in MakeTrigger

### DIFF
--- a/src/main/java/org/sonarlint/intellij/trigger/MakeTrigger.java
+++ b/src/main/java/org/sonarlint/intellij/trigger/MakeTrigger.java
@@ -27,12 +27,10 @@ import com.intellij.openapi.compiler.CompilerTopics;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import com.intellij.util.messages.MessageBusConnection;
+import java.util.UUID;
 import org.jetbrains.annotations.NotNull;
 import org.sonarlint.intellij.ui.SonarLintConsole;
 import org.sonarlint.intellij.util.SonarLintUtils;
-
-import javax.annotation.Nullable;
-import java.util.UUID;
 
 public class MakeTrigger implements BuildManagerListener, CompilationStatusListener, StartupActivity {
   private Project project;
@@ -54,9 +52,8 @@ public class MakeTrigger implements BuildManagerListener, CompilationStatusListe
     // nothing to do
   }
 
-  @Override public void buildFinished(@Nullable Project project, UUID sessionId, boolean isAutomake) {
-    // project is null in DummyCompileContext
-    if (project == null || !project.equals(this.project) || !isAutomake) {
+  @Override public void buildFinished(Project project, UUID sessionId, boolean isAutomake) {
+    if (!project.equals(this.project) || !isAutomake) {
       // covered by compilationFinished
       return;
     }

--- a/src/test/java/org/sonarlint/intellij/trigger/MakeTriggerTest.java
+++ b/src/test/java/org/sonarlint/intellij/trigger/MakeTriggerTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 import org.sonarlint.intellij.AbstractSonarLintMockedTests;
 import org.sonarlint.intellij.ui.SonarLintConsole;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -63,15 +62,6 @@ public class MakeTriggerTest extends AbstractSonarLintMockedTests {
   @Test
   public void should_do_nothing_on_generate() {
     trigger.fileGenerated("output", "relative");
-    verifyZeroInteractions(submitter);
-  }
-
-  @Test
-  public void handle_null_project() {
-    // this doesn't comply with the interface but it's null in DummyCompileContext
-    when(context.getProject()).thenReturn(null);
-    trigger.compilationFinished(false, 0, 0, context);
-    trigger.buildFinished(null, UUID.randomUUID(), true);
     verifyZeroInteractions(submitter);
   }
 


### PR DESCRIPTION
CompileContext::getProject was changed to @NotNull in
https://github.com/JetBrains/intellij-community/commit/07e8f9dacd61811216a109e89e1e20fd89f126f5#diff-1442c013914b9019d787cfcaef28615c
