### PR TITLE
SLI-433 Relax search criteria in rule configuration filter

### DIFF
--- a/src/main/java/org/sonarlint/intellij/config/global/rules/RulesFilterModel.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/rules/RulesFilterModel.java
@@ -19,7 +19,6 @@
  */
 package org.sonarlint.intellij.config.global.rules;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -117,10 +116,7 @@ public class RulesFilterModel {
       return true;
     }
 
-    List<String> split = new ArrayList<>();
-    split.addAll(tokenize(rule.getName()));
-    split.addAll(tokenize(rule.getKey()));
-    return Collections.indexOfSubList(split, tokenizedText) != -1;
+    return tokenizedText.stream().allMatch(t -> rule.getKey().equalsIgnoreCase(t) || rule.getName().toLowerCase(Locale.US).contains(t));
   }
 
   private static List<String> tokenize(@Nullable String str) {

--- a/src/test/java/org/sonarlint/intellij/config/global/rules/RulesFilterModelTest.java
+++ b/src/test/java/org/sonarlint/intellij/config/global/rules/RulesFilterModelTest.java
@@ -94,16 +94,25 @@ public class RulesFilterModelTest {
   public void should_apply_filter() {
     RulesTreeNode.Rule rule = mock(RulesTreeNode.Rule.class);
     when(rule.getName()).thenReturn("my rule");
+    when(rule.getKey()).thenReturn("my:rule");
     assertThat(model.filter(rule)).isTrue();
 
-    model.setText("my filter");
+    model.setText("my:rule");
+    assertThat(model.filter(rule)).isTrue();
 
+    when(rule.getKey()).thenReturn("other:rule");
+    assertThat(model.filter(rule)).isFalse();
+
+    model.setText("my filter");
     assertThat(model.filter(rule)).isFalse();
 
     when(rule.getName()).thenReturn("my filter");
     assertThat(model.filter(rule)).isTrue();
 
     when(rule.getName()).thenReturn("some text my filter and more text");
+    assertThat(model.filter(rule)).isTrue();
+
+    when(rule.getName()).thenReturn("some text in my title and more filtered text");
     assertThat(model.filter(rule)).isTrue();
 
     model.setShowOnlyEnabled(true);


### PR DESCRIPTION
I made sure that:
- search by rule key finds the exact rule (to avoid breaking the link in the rule description)
- all terms from the search criterion match (AND search)
- sub-words are matched (e.g "null" will match "nullpointerexception", "notnull", "nullable")