### PR TITLE
Fix duplicate key exception in analysis results handler

### DIFF
--- a/src/main/java/org/sonarlint/intellij/actions/ShowAnalysisResultsCallable.java
+++ b/src/main/java/org/sonarlint/intellij/actions/ShowAnalysisResultsCallable.java
@@ -27,9 +27,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonarlint.intellij.analysis.AnalysisCallback;
-import org.sonarlint.intellij.issue.IssueStore;
 import org.sonarlint.intellij.issue.IssueManager;
+import org.sonarlint.intellij.issue.IssueStore;
 import org.sonarlint.intellij.issue.LiveIssue;
 import org.sonarlint.intellij.util.SonarLintUtils;
 
@@ -53,7 +54,10 @@ public class ShowAnalysisResultsCallable implements AnalysisCallback {
     IssueManager issueManager = SonarLintUtils.getService(project, IssueManager.class);
     Map<VirtualFile, Collection<LiveIssue>> map = affectedFiles.stream()
       .filter(f -> !failedVirtualFiles.contains(f))
-      .collect(Collectors.toMap(Function.identity(), issueManager::getForFile));
+      .collect(Collectors.toMap(Function.identity(), issueManager::getForFile,
+        (liveIssuesA, liveIssuesB) -> Stream.of(liveIssuesA, liveIssuesB)
+          .flatMap(Collection::stream)
+          .collect(Collectors.toList())));
     IssueStore issueStore = SonarLintUtils.getService(project, IssueStore.class);
     issueStore.set(map, whatAnalyzed);
     showAnalysisResultsTab();


### PR DESCRIPTION
Please review our [contribution guidelines](https://github.com/SonarSource/sonarlint-intellij/blob/master/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SLI) ticket available, please make your commits and pull request start with the ticket ID (SLI-XXXX)


### Motive


In one of my projects, I'm seeing an error upon completion of running a full project sonarlint analysis:

```
Analysing 40 files...
Analysing 241 files...
Analysing 43 files...
Found 193 issues
Error running SonarLint analysis
java.lang.IllegalStateException: Duplicate key file:///Users/me/repos/42/foo/build/classes/generated/java/space/npstr/foo/db/gen/enums/Gameover.java (attempted merging values [] and [])
	at java.base/java.util.stream.Collectors.duplicateKeyException(Collectors.java:133)
	at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:180)
	at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at org.sonarlint.intellij.actions.ShowAnalysisResultsCallable.onSuccess(ShowAnalysisResultsCallable.java:56)
	at org.sonarlint.intellij.issue.IssueProcessor.process(IssueProcessor.java:98)
	at org.sonarlint.intellij.analysis.SonarLintTask.run(SonarLintTask.java:122)
	at org.sonarlint.intellij.analysis.SonarLintUserTask.run(SonarLintUserTask.java:38)
	at com.intellij.openapi.progress.impl.CoreProgressManager$TaskRunnable.run(CoreProgressManager.java:935)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcessWithProgressAsync$5(CoreProgressManager.java:442)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$3(ProgressRunner.java:235)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:170)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:629)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:581)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:157)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$4(ProgressRunner.java:235)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
	at java.base/java.lang.Thread.run(Thread.java:834)

Analysing 'build.gradle'...
Found 0 issues
```

I've also tried file exclusions in the form of
```
**/generated/**
**/db/gen/**
```
as a workaround (it should not be analyzing generated files in the first place) but those don't seem to help, so I am suggesting the attached patch to deal with potential duplicate keys.