### PR TITLE
Re-add closing of tip of the day for UI tests

### DIFF
--- a/its/src/test/kotlin/org/sonarlint/intellij/its/BaseUiTest.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/BaseUiTest.kt
@@ -323,6 +323,11 @@ open class BaseUiTest {
                     }
                 }
             }
+            idea {
+                // corresponding system property has been introduced around middle of 2020
+                // removable at some point when raising minimal version
+                closeTipOfTheDay()
+            }
         }
     }
 

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/fixtures/IdeaFrame.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/fixtures/IdeaFrame.kt
@@ -25,8 +25,10 @@ import com.intellij.remoterobot.fixtures.CommonContainerFixture
 import com.intellij.remoterobot.fixtures.DefaultXpath
 import com.intellij.remoterobot.fixtures.FixtureName
 import com.intellij.remoterobot.search.locators.byXpath
+import com.intellij.remoterobot.stepsProcessing.step
 import com.intellij.remoterobot.utils.WaitForConditionTimeoutException
 import com.intellij.remoterobot.utils.waitFor
+import org.sonarlint.intellij.its.utils.optionalStep
 import java.time.Duration
 
 fun RemoteRobot.idea(duration: Duration = Duration.ofSeconds(20), function: IdeaFrame.() -> Unit = {}): IdeaFrame {
@@ -39,6 +41,34 @@ class IdeaFrame(remoteRobot: RemoteRobot, remoteComponent: RemoteComponent) : Co
 
   private val ideStatusBar
     get() = find(IdeStatusBarFixture::class.java)
+
+    private fun dumbAware(timeout: Duration = Duration.ofMinutes(5), function: () -> Unit) {
+        step("Wait for smart mode") {
+            waitFor(duration = timeout, interval = Duration.ofSeconds(1)) {
+                runCatching { isDumbMode().not() }.getOrDefault(false)
+            }
+            function()
+            step("..wait for smart mode again") {
+                waitFor(duration = timeout, interval = Duration.ofSeconds(1)) {
+                    isDumbMode().not()
+                }
+            }
+        }
+    }
+
+    private fun isDumbMode(): Boolean {
+        return callJs("!component.project || com.intellij.openapi. project.DumbService.isDumb(component.project);", true)
+    }
+
+    fun closeTipOfTheDay() {
+        dumbAware {
+            optionalStep {
+                dialog("Tip of the Day", Duration.ofSeconds(1)) {
+                    button("Close").click()
+                }
+            }
+        }
+    }
 
   private fun isBackgroundTaskRunning(): Boolean {
     for (i in 0..1) {


### PR DESCRIPTION
The system property was introduced in mid-2020, we need to manually close the dialog prior those versions