### PR TITLE
SLI-310 Highlight info issues as weak warnings

### DIFF
--- a/src/main/java/org/sonarlint/intellij/util/SonarLintSeverity.java
+++ b/src/main/java/org/sonarlint/intellij/util/SonarLintSeverity.java
@@ -34,7 +34,7 @@ public enum SonarLintSeverity {
   CRITICAL(CodeInsightColors.WARNINGS_ATTRIBUTES, ProblemHighlightType.GENERIC_ERROR_OR_WARNING, HighlightSeverity.WARNING),
   MAJOR(CodeInsightColors.WARNINGS_ATTRIBUTES, ProblemHighlightType.GENERIC_ERROR_OR_WARNING, HighlightSeverity.WARNING),
   MINOR(CodeInsightColors.WARNINGS_ATTRIBUTES, ProblemHighlightType.GENERIC_ERROR_OR_WARNING, HighlightSeverity.WARNING),
-  INFO(CodeInsightColors.WARNINGS_ATTRIBUTES, ProblemHighlightType.GENERIC_ERROR_OR_WARNING, HighlightSeverity.WEAK_WARNING);
+  INFO(CodeInsightColors.WARNINGS_ATTRIBUTES, ProblemHighlightType.WEAK_WARNING, HighlightSeverity.WEAK_WARNING);
 
   private static final Map<String, SonarLintSeverity> cache = Stream.of(values()).collect(Collectors.toMap(Enum::toString, Function.identity()));
 

--- a/src/test/java/org/sonarlint/intellij/util/SonarLintSeverityTest.java
+++ b/src/test/java/org/sonarlint/intellij/util/SonarLintSeverityTest.java
@@ -47,7 +47,7 @@ public class SonarLintSeverityTest {
   @Test
   public void testInfoSeverity() {
     assertThat(SonarLintSeverity.INFO.highlightSeverity()).isEqualTo(HighlightSeverity.WEAK_WARNING);
-    assertThat(SonarLintSeverity.INFO.highlightType()).isEqualTo(ProblemHighlightType.GENERIC_ERROR_OR_WARNING);
+    assertThat(SonarLintSeverity.INFO.highlightType()).isEqualTo(ProblemHighlightType.WEAK_WARNING);
     assertThat(SonarLintSeverity.INFO.defaultTextAttributes()).isEqualTo(CodeInsightColors.WARNINGS_ATTRIBUTES);
   }
 }


### PR DESCRIPTION
In 2018 @dbmeneses made the change "Highlight info issues as weak warnings" for SLI-310.
However, the change was incomplete as info issues are still highlighted identical to regular warnings. This is because the ProblemHighlightType must also be changed as well. 
![image](https://user-images.githubusercontent.com/4466272/195447606-ddc7153d-ad26-4131-8649-9d8accf12573.png)


This is what the highlight would look like with these new settings. I actually couldn't get sonarlint to build (failed to resolve dependencies), so this screenshot is from a different plugin that I wrote using the same highlighting settings.
![image](https://user-images.githubusercontent.com/4466272/195450051-13255d53-b617-41d1-9e6e-9ddc6f48d297.png)

This change is important as without it, there are lint issues that we will be forced to disable to prevent them from drowning out more important issues.

In SLI-309 it says "Users can always configure the way issues are shown in the settings." but I do not see how to do this, nor can I find any code implementing that feature.
