### PR TITLE
SLI-851 Add support for clang-cl

### DIFF
--- a/clion/src/main/java/org/sonarlint/intellij/clion/AnalyzerConfiguration.java
+++ b/clion/src/main/java/org/sonarlint/intellij/clion/AnalyzerConfiguration.java
@@ -176,6 +176,8 @@ public class AnalyzerConfiguration {
       case "Clang":
       case "GCC":
         return "clang";
+      case "clang-cl":
+        return "clang-cl";
       case "MSVC":
         return "msvc-cl";
       default:

--- a/clion/src/test/java/org/sonarlint/intellij/clion/AnalyzerConfigurationTest.java
+++ b/clion/src/test/java/org/sonarlint/intellij/clion/AnalyzerConfigurationTest.java
@@ -88,7 +88,7 @@ class AnalyzerConfigurationTest {
   void map_to_cfamily_compiler() {
     assertEquals("clang", AnalyzerConfiguration.mapToCFamilyCompiler(OCCompilerKind.CLANG));
     assertEquals("clang", AnalyzerConfiguration.mapToCFamilyCompiler(OCCompilerKind.GCC));
-    assertNull(AnalyzerConfiguration.mapToCFamilyCompiler(OCCompilerKind.CLANG_CL));
+    assertEquals("clang-cl", AnalyzerConfiguration.mapToCFamilyCompiler(OCCompilerKind.CLANG_CL));
     assertEquals("msvc-cl", AnalyzerConfiguration.mapToCFamilyCompiler(OCCompilerKind.MSVC));
     assertEquals("clang", AnalyzerConfiguration.mapToCFamilyCompiler(APPLE_CLANG_COMPILER));
   }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -57,7 +57,7 @@
 
     <change-notes><![CDATA[
       <ul>
-        <li>8.0 - Support of JavaScript analysis in HTML files. New quick fix for a C++ rule. New quick fixes for 4 Python rules. Bug fixes, fewer FPs and improvements for many languages.</li>
+        <li>8.0 - Support of JavaScript analysis in HTML files. Support for clang-cl and Microchip compilers. New quick fix for a C++ rule. New quick fixes for 4 Python rules. Bug fixes, fewer FPs and improvements for many languages.</li>
         <li>7.4 - Display Clean Code principles in rule descriptions. 13 new rules around std::format for C++. 1 new rule for Java. Bug fixes, fewer FPs and improvements for many languages.</li>
         <li>7.3 - Improved display of rule descriptions. New react performance rules. Analyze CSS files. New Kotlin rules. 6 new C++20 rules. Support Python 3.11. Analyze JS, TS, CSS and HTML in Rider. 1 new rule for C# in Rider. Many rules improvements.</li>
         <li>7.2.1 - Fix an error when selecting issues or taint vulnerabilities in the tool window in 2022.3.</li>


### PR DESCRIPTION
This is blocked by CPP-2455. Once the CFamily plugin is released, as far as I can see this is the only required change to enable clang-cl in CLion. 