### PR TITLE
Feature/tha/sli 940 go go go

### DIFF
--- a/its/src/test/kotlin/org/sonarlint/intellij/its/BaseUiTest.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/BaseUiTest.kt
@@ -37,6 +37,7 @@ import org.sonarlint.intellij.its.fixtures.editor
 import org.sonarlint.intellij.its.fixtures.idea
 import org.sonarlint.intellij.its.fixtures.isCLion
 import org.sonarlint.intellij.its.fixtures.isGoLand
+import org.sonarlint.intellij.its.fixtures.isGoPlugin
 import org.sonarlint.intellij.its.fixtures.openProjectFileBrowserDialog
 import org.sonarlint.intellij.its.fixtures.preferencesDialog
 import org.sonarlint.intellij.its.fixtures.tool.window.TabContentFixture
@@ -73,10 +74,21 @@ open class BaseUiTest {
             return remoteRobot.isCLion()
         }
 
+        /**
+         *  This only checks for the GoLand IDE, if you want to check for the Go language support in general (via the
+         *  Go plugin), use [BaseUiTest.isGoPlugin]!
+         */
         @JvmStatic
         fun isGoLand(): Boolean {
             return remoteRobot.isGoLand()
         }
+
+        /**
+         *  This one checks for the Go language support in general (via the Go plugin), if you want to check for the
+         *  GoLand IDE, use [BaseUiTest.isGoLand]!
+         */
+        @JvmStatic
+        fun isGoPlugin(): Boolean = remoteRobot.isGoPlugin()
     }
 
 

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/fixtures/RemoteRobotExtensions.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/fixtures/RemoteRobotExtensions.kt
@@ -26,3 +26,15 @@ fun RemoteRobot.ideMajorVersion() = callJs<Int>("com.intellij.openapi.applicatio
 fun RemoteRobot.isCLion() = callJs<Boolean>("com.intellij.util.PlatformUtils.isCLion()")
 
 fun RemoteRobot.isGoLand() = callJs<Boolean>("com.intellij.util.PlatformUtils.isGoIde()")
+
+/**
+ *  Check if the Go plugin is available, currently bundled in GoLand and as a plugin from the marketplace for IntelliJ
+ *  IDEA Ultimate. The plugin was [open source](https://github.com/go-lang-plugin-org/go-lang-idea-plugin/tree/master)
+ *  but is now closed source and property of JetBrains. As the SDK provides no API for getting a list of all installed
+ *  plugin ids (Go plugin id: org.jetbrains.plugins.go), we have to test for the actual
+ *  [implementation](https://github.com/go-lang-plugin-org/go-lang-idea-plugin/blob/master/src/com/goide/GoLanguage.java),
+ *  which hasn't changed for over 8+ years.
+ */
+fun RemoteRobot.isGoPlugin() = callJs<Boolean>(
+    "try { java.lang.Class.forName('com.goide.GoLanguage'); return true; } catch (ignored) { return false; }"
+)

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/fixtures/RemoteRobotExtensions.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/fixtures/RemoteRobotExtensions.kt
@@ -35,6 +35,4 @@ fun RemoteRobot.isGoLand() = callJs<Boolean>("com.intellij.util.PlatformUtils.is
  *  [implementation](https://github.com/go-lang-plugin-org/go-lang-idea-plugin/blob/master/src/com/goide/GoLanguage.java),
  *  which hasn't changed for over 8+ years.
  */
-fun RemoteRobot.isGoPlugin() = callJs<Boolean>(
-    "try { java.lang.Class.forName('com.goide.GoLanguage'); return true; } catch (ignored) { return false; }"
-)
+fun RemoteRobot.isGoPlugin() = callJs<Boolean>("function isClassAvailable() { try { java.lang.Class.forName('com.goide.GoLanguage'); return true; } catch(_) { return false; } } isClassAvailable();")

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/fixtures/RemoteRobotExtensions.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/fixtures/RemoteRobotExtensions.kt
@@ -30,9 +30,7 @@ fun RemoteRobot.isGoLand() = callJs<Boolean>("com.intellij.util.PlatformUtils.is
 /**
  *  Check if the Go plugin is available, currently bundled in GoLand and as a plugin from the marketplace for IntelliJ
  *  IDEA Ultimate. The plugin was [open source](https://github.com/go-lang-plugin-org/go-lang-idea-plugin/tree/master)
- *  but is now closed source and property of JetBrains. As the SDK provides no API for getting a list of all installed
- *  plugin ids (Go plugin id: org.jetbrains.plugins.go), we have to test for the actual
- *  [implementation](https://github.com/go-lang-plugin-org/go-lang-idea-plugin/blob/master/src/com/goide/GoLanguage.java),
- *  which hasn't changed for over 8+ years.
+ *  but is now closed source and property of JetBrains. We have to check via the PluginManager to find the plugin by its
+ *  id, not its name: org.jetbrains.plugins.go
  */
-fun RemoteRobot.isGoPlugin() = callJs<Boolean>("function isClassAvailable() { try { java.lang.Class.forName('com.goide.GoLanguage'); return true; } catch(_) { return false; } } isClassAvailable();")
+fun RemoteRobot.isGoPlugin() = callJs<Boolean>("com.intellij.ide.plugins.PluginManager.isPluginInstalled(com.intellij.openapi.extensions.PluginId.getId('org.jetbrains.plugins.go'))")

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/tests/GoLanguageTests.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/tests/GoLanguageTests.kt
@@ -24,9 +24,9 @@ import org.junit.jupiter.api.condition.EnabledIf
 import org.sonarlint.intellij.its.BaseUiTest
 
 
-@EnabledIf("isGoLand")
-class GoLandTests : BaseUiTest() {
-
+/** Tests for Go language support (not limited to GoLand) */
+@EnabledIf("isGoPlugin")
+class GoLanguageTests : BaseUiTest() {
     @Test
     fun should_analyze_go() = uiTest {
         openExistingProject("sample-go")
@@ -39,5 +39,4 @@ class GoLandTests : BaseUiTest() {
             "Remove or correct this useless self-assignment."
         )
     }
-
 }

--- a/src/main/java/org/sonarlint/intellij/go/GoLanguageActivator.java
+++ b/src/main/java/org/sonarlint/intellij/go/GoLanguageActivator.java
@@ -17,12 +17,16 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonarlint.intellij.goland;
+package org.sonarlint.intellij.go;
 
 import java.util.Set;
 import org.sonarlint.intellij.common.LanguageActivator;
 import org.sonarsource.sonarlint.core.commons.Language;
 
+/**
+ *  The Go language is provided via the Go plugin, it's bundled inside the GoLand installation and currently only
+ *  available for IntelliJ IDEA Ultimate <a href="https://plugins.jetbrains.com/plugin/9568-go">the marketplace</a>.
+ */
 public class GoLanguageActivator implements LanguageActivator {
   @Override
   public void amendLanguages(Set<Language> enabledLanguages) {

--- a/src/main/java/org/sonarlint/intellij/go/GoLanguageActivator.java
+++ b/src/main/java/org/sonarlint/intellij/go/GoLanguageActivator.java
@@ -25,7 +25,7 @@ import org.sonarsource.sonarlint.core.commons.Language;
 
 /**
  *  The Go language is provided via the Go plugin, it's bundled inside the GoLand installation and currently only
- *  available for IntelliJ IDEA Ultimate <a href="https://plugins.jetbrains.com/plugin/9568-go">the marketplace</a>.
+ *  available for IntelliJ IDEA Ultimate from the <a href="https://plugins.jetbrains.com/plugin/9568-go">marketplace</a>
  */
 public class GoLanguageActivator implements LanguageActivator {
   @Override

--- a/src/main/resources/META-INF/plugin-go.xml
+++ b/src/main/resources/META-INF/plugin-go.xml
@@ -21,7 +21,7 @@
 -->
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
     <extensions defaultExtensionNs="org.sonarlint.idea">
-        <languageActivator implementation="org.sonarlint.intellij.goland.GoLanguageActivator"/>
+        <languageActivator implementation="org.sonarlint.intellij.go.GoLanguageActivator"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -162,9 +162,9 @@
          on how to target different products -->
     <depends>com.intellij.modules.lang</depends>
     <depends optional="true" config-file="plugin-git.xml">Git4Idea</depends>
+    <depends optional="true" config-file="plugin-go.xml">org.jetbrains.plugins.go</depends>
     <depends optional="true" config-file="plugin-java.xml">com.intellij.modules.java</depends>
     <depends optional="true" config-file="plugin-clion.xml">com.intellij.modules.clion</depends>
-    <depends optional="true" config-file="plugin-goland.xml">com.intellij.modules.goland</depends>
     <depends optional="true" config-file="plugin-rider.xml">com.intellij.modules.rider</depends>
 
     <projectListeners>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -64,6 +64,7 @@
 
     <change-notes><![CDATA[
       <ul>
+        <li>8.3 - Support analysis of Go not only in GoLand but also when using the Go plugin in IntelliJ IDEA Ultimate.</li>
         <li>8.2 - Support syntax highlighting and diff view for code examples. Add support for CloudFormation, Docker, Kubernetes and Terraform. 3 new rules for Java. 8 new rules for JavaScript. 2 new rules for C# in Rider. 9 new rules for Kotlin. 11 new rules, 3 new quick fixes for Python. Bug fixes, fewer FPs and improvements for many languages.</li>
         <li>8.1 - Support analysis of Go in GoLand. Support for tiarmclang compiler, Kotlin 1.8 and IPython syntax. 6 new rules for C# in Rider. Bug fixes, fewer FPs and improvements for many languages.</li>
         <li>8.0 - Raise minimal supported version to 2021.3. Report Security Hotspots locally when connected to SonarQube 9.7+. Support of JavaScript analysis in HTML files. Support for clang-cl and Microchip compilers. New quick fixes for 11 Java rules. New quick fix for a C++ rule. New quick fixes for 17 Python rules. 6 new rules for C# in Rider. Bug fixes, fewer FPs and improvements for many languages.</li>


### PR DESCRIPTION
## Summary

GoLand includes the Go plugin, which can be used in IntelliJ IDEA Ultimate. Therefore depend on the shared plugin rather than the IDE for the Go support.

## Tests

Changed the ITs to match the change from only GoLand support to both GoLand and the Go plugin. The GoLand installation comes bundled with the Go plugin, therefore it does not appear in the "installed plugin" view in the settings.