### PR TITLE
SLI-950 Hide resolved hotspots from report, fix selection, fix highlight

### DIFF
--- a/src/main/java/org/sonarlint/intellij/actions/ReviewSecurityHotspotAction.kt
+++ b/src/main/java/org/sonarlint/intellij/actions/ReviewSecurityHotspotAction.kt
@@ -55,6 +55,7 @@ class ReviewSecurityHotspotAction(private var serverFindingKey: String? = null, 
 
     override fun isEnabled(e: AnActionEvent, project: Project, status: AnalysisStatus): Boolean {
         return e.getData(SECURITY_HOTSPOT_KEY) != null && e.getData(SECURITY_HOTSPOT_KEY)?.serverFindingKey != null
+            && e.getData(SECURITY_HOTSPOT_KEY)?.isValid == true
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/java/org/sonarlint/intellij/actions/SonarLintToolWindow.java
+++ b/src/main/java/org/sonarlint/intellij/actions/SonarLintToolWindow.java
@@ -28,11 +28,11 @@ import com.intellij.ui.ColorUtil;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManagerEvent;
 import com.intellij.util.ui.UIUtil;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import javax.swing.SwingUtilities;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -51,6 +51,7 @@ import org.sonarlint.intellij.ui.CurrentFilePanel;
 import org.sonarlint.intellij.ui.ReportPanel;
 import org.sonarlint.intellij.ui.SecurityHotspotsPanel;
 import org.sonarlint.intellij.ui.SonarLintToolWindowFactory;
+import org.sonarlint.intellij.ui.nodes.LiveSecurityHotspotNode;
 import org.sonarlint.intellij.ui.vulnerabilities.TaintVulnerabilitiesPanel;
 import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.HotspotStatus;
 import org.sonarsource.sonarlint.core.commons.RuleType;
@@ -95,7 +96,7 @@ public class SonarLintToolWindow implements ContentManagerListenerAdapter {
     var content = getSecurityHotspotContent();
     if (content != null) {
       var hotspotsPanel = (SecurityHotspotsPanel) content.getComponent();
-      var hotspotsCount = hotspotsPanel.filterSecurityHotspots(filter);
+      var hotspotsCount = hotspotsPanel.filterSecurityHotspots(project, filter);
       content.setDisplayName(buildTabName(hotspotsCount, SonarLintToolWindowFactory.SECURITY_HOTSPOTS_TAB_TITLE));
     }
   }
@@ -293,17 +294,11 @@ public class SonarLintToolWindow implements ContentManagerListenerAdapter {
     }
   }
 
-  public Collection<LiveSecurityHotspot> getDisplayedSecurityHotspots(Collection<LiveSecurityHotspot> securityHotspots) {
+  public Collection<LiveSecurityHotspot> getDisplayedSecurityHotspots() {
     var toolWindow = getToolWindow();
-    if (toolWindow != null && toolWindow.isVisible() && securityHotspotsContent != null  && securityHotspotsContent.isSelected()) {
+    if (toolWindow != null && toolWindow.isVisible() && securityHotspotsContent != null && securityHotspotsContent.isSelected()) {
       var securityHotspotPanel = (SecurityHotspotsPanel) securityHotspotsContent.getComponent();
-      var displayedSecurityHotspots = new ArrayList<LiveSecurityHotspot>();
-      securityHotspotPanel.getDisplayedNodes().forEach(filteredNode -> {
-        if (securityHotspots.contains(filteredNode.getHotspot())) {
-          displayedSecurityHotspots.add(filteredNode.getHotspot());
-        }
-      });
-      return displayedSecurityHotspots;
+      return securityHotspotPanel.getDisplayedNodes().stream().map(LiveSecurityHotspotNode::getHotspot).collect(Collectors.toList());
     }
     return Collections.emptyList();
   }

--- a/src/main/java/org/sonarlint/intellij/editor/SonarExternalAnnotator.java
+++ b/src/main/java/org/sonarlint/intellij/editor/SonarExternalAnnotator.java
@@ -77,17 +77,15 @@ public class SonarExternalAnnotator extends ExternalAnnotator<SonarExternalAnnot
       });
 
     var toolWindowService = getService(project, SonarLintToolWindow.class);
-    if (toolWindowService.isSecurityHotspotsTabActive()) {
-      var securityHotspots = issueManager.getSecurityHotspotsForFile(file.getVirtualFile());
-      securityHotspots
-        .forEach(securityHotspot -> {
-          // reject ranges that are no longer valid. It probably means that they were deleted from the file, or the file was deleted
-          var validTextRange = securityHotspot.getValidTextRange();
-          if (validTextRange != null) {
-            addAnnotation(project, securityHotspot, validTextRange, holder);
-          }
-        });
-    }
+    var securityHotspots = issueManager.getSecurityHotspotsForFile(file.getVirtualFile());
+    toolWindowService.getDisplayedSecurityHotspots(securityHotspots)
+      .forEach(securityHotspot -> {
+        // reject ranges that are no longer valid. It probably means that they were deleted from the file, or the file was deleted
+        var validTextRange = securityHotspot.getValidTextRange();
+        if (validTextRange != null) {
+          addAnnotation(project, securityHotspot, validTextRange, holder);
+        }
+      });
 
     if (SonarLintUtils.isTaintVulnerabilitiesEnabled()) {
       getService(project, TaintVulnerabilitiesPresenter.class).getCurrentVulnerabilitiesByFile()

--- a/src/main/java/org/sonarlint/intellij/editor/SonarExternalAnnotator.java
+++ b/src/main/java/org/sonarlint/intellij/editor/SonarExternalAnnotator.java
@@ -76,9 +76,9 @@ public class SonarExternalAnnotator extends ExternalAnnotator<SonarExternalAnnot
         }
       });
 
+    // only annotate the hotspots currently displayed in the tree
     var toolWindowService = getService(project, SonarLintToolWindow.class);
-    var securityHotspots = issueManager.getSecurityHotspotsForFile(file.getVirtualFile());
-    toolWindowService.getDisplayedSecurityHotspots(securityHotspots)
+    toolWindowService.getDisplayedSecurityHotspots()
       .forEach(securityHotspot -> {
         // reject ranges that are no longer valid. It probably means that they were deleted from the file, or the file was deleted
         var validTextRange = securityHotspot.getValidTextRange();

--- a/src/main/java/org/sonarlint/intellij/ui/ReportPanel.java
+++ b/src/main/java/org/sonarlint/intellij/ui/ReportPanel.java
@@ -54,6 +54,7 @@ import org.sonarlint.intellij.ui.tree.IssueTreeModelBuilder;
 import org.sonarlint.intellij.ui.tree.SecurityHotspotTree;
 import org.sonarlint.intellij.ui.tree.SecurityHotspotTreeModelBuilder;
 import org.sonarlint.intellij.util.SonarLintActions;
+import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.HotspotStatus;
 
 import static org.sonarlint.intellij.ui.SonarLintToolWindowFactory.createSplitter;
 import static org.sonarlint.intellij.ui.UiUtils.runOnUiThread;
@@ -109,6 +110,13 @@ public class ReportPanel extends SimpleToolWindowPanel implements Disposable {
     }
 
     expandTree();
+  }
+
+  public void updateStatusForSecurityHotspot(String securityHotspotKey, HotspotStatus status) {
+    var wasUpdated = securityHotspotTreeBuilder.updateStatusForHotspotWithFileNode(securityHotspotKey, status);
+    if (wasUpdated) {
+      expandTree();
+    }
   }
 
   private void initPanel() {

--- a/src/main/java/org/sonarlint/intellij/ui/SecurityHotspotsPanel.java
+++ b/src/main/java/org/sonarlint/intellij/ui/SecurityHotspotsPanel.java
@@ -267,12 +267,15 @@ public class SecurityHotspotsPanel extends SimpleToolWindowPanel implements Disp
   }
 
   private int displaySecurityHotspotsAfterFiltering(int filteredCount) {
-    if (filteredCount == 0) {
-      cardPanel.show(NO_SECURITY_HOTSPOT_FILTERED_CARD_ID);
-    } else {
-      cardPanel.show(SECURITY_HOTSPOTS_LIST_CARD_ID);
+    if (status instanceof Supported) {
+      if (filteredCount == 0) {
+        cardPanel.show(NO_SECURITY_HOTSPOT_FILTERED_CARD_ID);
+      } else {
+        cardPanel.show(SECURITY_HOTSPOTS_LIST_CARD_ID);
+      }
+      return filteredCount;
     }
-    return filteredCount;
+    return 0;
   }
 
   public boolean trySelectSecurityHotspot(String securityHotspotKey) {
@@ -306,6 +309,10 @@ public class SecurityHotspotsPanel extends SimpleToolWindowPanel implements Disp
 
   public void selectRulesTab() {
     detailsTab.setSelectedIndex(RULE_TAB_INDEX);
+  }
+
+  public Collection<LiveSecurityHotspotNode> getDisplayedNodes() {
+    return securityHotspotTreeBuilder.getFilteredNodes();
   }
 
   @Override

--- a/src/main/java/org/sonarlint/intellij/ui/SecurityHotspotsPanel.java
+++ b/src/main/java/org/sonarlint/intellij/ui/SecurityHotspotsPanel.java
@@ -163,7 +163,7 @@ public class SecurityHotspotsPanel extends SimpleToolWindowPanel implements Disp
       TreeUtil.expandAll(securityHotspotTree);
       displaySecurityHotspots();
 
-      return applyCurrentFiltering();
+      return applyCurrentFiltering(project);
     } else {
       return 0;
     }
@@ -287,20 +287,20 @@ public class SecurityHotspotsPanel extends SimpleToolWindowPanel implements Disp
     return false;
   }
 
-  public int applyCurrentFiltering() {
-    return displaySecurityHotspotsAfterFiltering(securityHotspotTreeBuilder.applyCurrentFiltering());
+  public int applyCurrentFiltering(Project project) {
+    return displaySecurityHotspotsAfterFiltering(securityHotspotTreeBuilder.applyCurrentFiltering(project));
   }
 
   public int updateStatusAndApplyCurrentFiltering(String securityHotspotKey, HotspotStatus status) {
-    return displaySecurityHotspotsAfterFiltering(securityHotspotTreeBuilder.updateStatusAndApplyCurrentFiltering(securityHotspotKey, status));
+    return displaySecurityHotspotsAfterFiltering(securityHotspotTreeBuilder.updateStatusAndApplyCurrentFiltering(project, securityHotspotKey, status));
   }
 
   public void selectAndHighlightSecurityHotspot(LiveSecurityHotspot securityHotspot) {
     updateOnSelect(securityHotspot);
   }
 
-  public int filterSecurityHotspots(SecurityHotspotFilters filter) {
-    return displaySecurityHotspotsAfterFiltering(securityHotspotTreeBuilder.filterSecurityHotspots(filter));
+  public int filterSecurityHotspots(Project project, SecurityHotspotFilters filter) {
+    return displaySecurityHotspotsAfterFiltering(securityHotspotTreeBuilder.filterSecurityHotspots(project, filter));
   }
 
   public void selectLocationsTab() {

--- a/src/main/java/org/sonarlint/intellij/ui/SonarLintRulePanel.kt
+++ b/src/main/java/org/sonarlint/intellij/ui/SonarLintRulePanel.kt
@@ -297,7 +297,7 @@ class SonarLintRulePanel(private val project: Project, private val parent: Dispo
 
             }
             SwingHelper.setHtml(securityHotspotHeaderMessage, htmlStringBuilder.toString(), JBUI.CurrentTheme.ContextHelp.FOREGROUND)
-            headerPanel.update(project, serverFindingKey, finding.status, finding.file, ruleDescription.key, ruleDescription.type, finding.vulnerabilityProbability)
+            headerPanel.update(project, serverFindingKey, finding.status, finding.isValid, finding.file, ruleDescription.key, ruleDescription.type, finding.vulnerabilityProbability)
         } else {
             headerPanel.update(ruleDescription.key, ruleDescription.type, ruleDescription.severity)
         }

--- a/src/main/java/org/sonarlint/intellij/ui/nodes/SummaryNode.java
+++ b/src/main/java/org/sonarlint/intellij/ui/nodes/SummaryNode.java
@@ -22,9 +22,7 @@ package org.sonarlint.intellij.ui.nodes;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.stream.Collectors;
-import org.sonarlint.intellij.ui.tree.FindingTreeIndex;
 import org.sonarlint.intellij.ui.tree.TreeCellRenderer;
-import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.HotspotStatus;
 
 public class SummaryNode extends AbstractNode {
   private String emptyText;
@@ -97,28 +95,6 @@ public class SummaryNode extends AbstractNode {
     int insertIdx = -foundIndex - 1;
     insert(newChild, insertIdx);
     return insertIdx;
-  }
-
-  public void updateLiveSecurityHotspotNodeFromFileNode(String securityHotspotKey, HotspotStatus status, FindingTreeIndex index) {
-    var fileNodes = children.stream().map(n -> (FileNode) n).collect(Collectors.<FileNode>toList());
-    for (var fileNode : fileNodes) {
-      var children = fileNode.children();
-      while(children.hasMoreElements()) {
-        var hotspotNode = (LiveSecurityHotspotNode) children.nextElement();
-        var hotspot = hotspotNode.getHotspot();
-        if (securityHotspotKey.equals(hotspot.getServerFindingKey())) {
-          hotspot.setStatus(status);
-          if (hotspot.isResolved()) {
-            fileNode.remove(hotspotNode);
-            if (fileNode.getFindingCount() == 0) {
-              index.remove(fileNode.file());
-              remove(fileNode);
-            }
-          }
-          return;
-        }
-      }
-    }
   }
 
   @Override

--- a/src/main/java/org/sonarlint/intellij/ui/nodes/SummaryNode.java
+++ b/src/main/java/org/sonarlint/intellij/ui/nodes/SummaryNode.java
@@ -22,7 +22,9 @@ package org.sonarlint.intellij.ui.nodes;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.stream.Collectors;
+import org.sonarlint.intellij.ui.tree.FindingTreeIndex;
 import org.sonarlint.intellij.ui.tree.TreeCellRenderer;
+import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.HotspotStatus;
 
 public class SummaryNode extends AbstractNode {
   private String emptyText;
@@ -95,6 +97,28 @@ public class SummaryNode extends AbstractNode {
     int insertIdx = -foundIndex - 1;
     insert(newChild, insertIdx);
     return insertIdx;
+  }
+
+  public void updateLiveSecurityHotspotNodeFromFileNode(String securityHotspotKey, HotspotStatus status, FindingTreeIndex index) {
+    var fileNodes = children.stream().map(n -> (FileNode) n).collect(Collectors.<FileNode>toList());
+    for (var fileNode : fileNodes) {
+      var children = fileNode.children();
+      while(children.hasMoreElements()) {
+        var hotspotNode = (LiveSecurityHotspotNode) children.nextElement();
+        var hotspot = hotspotNode.getHotspot();
+        if (securityHotspotKey.equals(hotspot.getServerFindingKey())) {
+          hotspot.setStatus(status);
+          if (hotspot.isResolved()) {
+            fileNode.remove(hotspotNode);
+            if (fileNode.getFindingCount() == 0) {
+              index.remove(fileNode.file());
+              remove(fileNode);
+            }
+          }
+          return;
+        }
+      }
+    }
   }
 
   @Override

--- a/src/main/java/org/sonarlint/intellij/ui/ruledescription/RuleHeaderPanel.kt
+++ b/src/main/java/org/sonarlint/intellij/ui/ruledescription/RuleHeaderPanel.kt
@@ -104,6 +104,7 @@ class RuleHeaderPanel : JBPanel<RuleHeaderPanel>(FlowLayout(FlowLayout.LEFT)) {
         project: Project,
         securityHotspotKey: String?,
         status: HotspotReviewStatus,
+        isValid: Boolean,
         file: VirtualFile,
         ruleKey: String,
         type: RuleType,
@@ -124,7 +125,7 @@ class RuleHeaderPanel : JBPanel<RuleHeaderPanel>(FlowLayout(FlowLayout.LEFT)) {
                     ReviewSecurityHotspotAction(securityHotspotKey, status).openReviewingDialog(project, file)
                 }
             }
-            changeStatusButton.isVisible = true
+            changeStatusButton.isVisible = isValid
         }
     }
 

--- a/src/main/java/org/sonarlint/intellij/ui/tree/SecurityHotspotTreeModelBuilder.java
+++ b/src/main/java/org/sonarlint/intellij/ui/tree/SecurityHotspotTreeModelBuilder.java
@@ -46,6 +46,13 @@ import org.sonarsource.sonarlint.core.commons.VulnerabilityProbability;
 /**
  * Responsible for maintaining the tree model and send change events when needed.
  * Should be optimized to minimize the recreation of portions of the tree.
+ *
+ * There are 2 implementations within this class
+ * - Security hotspots within a file node (used for the report tab)
+ * - Security hotspots directly child of the summary node (used for the security hotspots tab)
+ *
+ * In the report tab, there is no filtering mechanism, the nodes are simply deleted when needed
+ * In the security hotspots tab, there is a filtering mechanism that hides or not some nodes
  */
 public class SecurityHotspotTreeModelBuilder implements FindingTreeModelBuilder {
   private static final List<VulnerabilityProbability> VULNERABILITY_PROBABILITIES = List.of(VulnerabilityProbability.HIGH,
@@ -58,7 +65,7 @@ public class SecurityHotspotTreeModelBuilder implements FindingTreeModelBuilder 
   private DefaultTreeModel model;
   private SummaryNode summary;
   private List<LiveSecurityHotspotNode> nonFilteredNodes;
-  private int filteredCount;
+  private List<LiveSecurityHotspotNode> filteredNodes;
 
   public SecurityHotspotTreeModelBuilder() {
     this.index = new FindingTreeIndex();
@@ -72,7 +79,7 @@ public class SecurityHotspotTreeModelBuilder implements FindingTreeModelBuilder 
     model = new DefaultTreeModel(summary);
     model.setRoot(summary);
     nonFilteredNodes = new ArrayList<>();
-    filteredCount = 0;
+    filteredNodes = new ArrayList<>();
     return model;
   }
 
@@ -89,6 +96,7 @@ public class SecurityHotspotTreeModelBuilder implements FindingTreeModelBuilder 
 
     var toRemove = index.getAllFiles().stream().filter(f -> !map.containsKey(f)).collect(Collectors.toList());
 
+    nonFilteredNodes.clear();
     toRemove.forEach(this::removeFile);
 
     for (var e : map.entrySet()) {
@@ -104,7 +112,7 @@ public class SecurityHotspotTreeModelBuilder implements FindingTreeModelBuilder 
       return;
     }
 
-    var filtered = filter(securityHotspots);
+    var filtered = filter(securityHotspots, false);
     if (filtered.isEmpty()) {
       removeFile(file);
       return;
@@ -131,7 +139,7 @@ public class SecurityHotspotTreeModelBuilder implements FindingTreeModelBuilder 
     }
   }
 
-  private static void setFileNodeSecurityHotspots(FileNode node, Iterable<LiveSecurityHotspot> securityHotspotsPointer) {
+  private void setFileNodeSecurityHotspots(FileNode node, Iterable<LiveSecurityHotspot> securityHotspotsPointer) {
     node.removeAllChildren();
 
     var securityHotspots = new TreeSet<>(SECURITY_HOTSPOT_COMPARATOR);
@@ -143,6 +151,8 @@ public class SecurityHotspotTreeModelBuilder implements FindingTreeModelBuilder 
     for (var securityHotspot : securityHotspots) {
       var iNode = new LiveSecurityHotspotNode(securityHotspot, false);
       node.add(iNode);
+
+      nonFilteredNodes.add(iNode);
     }
   }
 
@@ -192,7 +202,7 @@ public class SecurityHotspotTreeModelBuilder implements FindingTreeModelBuilder 
       return;
     }
 
-    var filtered = filter(securityHotspots);
+    var filtered = filter(securityHotspots, true);
     if (filtered.isEmpty()) {
       removeHotspotsByFile(file);
       return;
@@ -246,9 +256,22 @@ public class SecurityHotspotTreeModelBuilder implements FindingTreeModelBuilder 
     return filterSecurityHotspots(currentFilter);
   }
 
+  public boolean updateStatusForHotspotWithFileNode(String securityHotspotKey, HotspotStatus status) {
+    if (numberHotspots() > 0) {
+      summary.updateLiveSecurityHotspotNodeFromFileNode(securityHotspotKey, status, index);
+      model.reload();
+      return true;
+    }
+    return false;
+  }
+
+  public Collection<LiveSecurityHotspotNode> getFilteredNodes() {
+    return filteredNodes;
+  }
+
   public int filterSecurityHotspots(SecurityHotspotFilters filter) {
     currentFilter = filter;
-    var currentlyFilteredCount = 0;
+    filteredNodes.clear();
     Collections.list(summary.children()).forEach(e -> model.removeNodeFromParent((LiveSecurityHotspotNode) e));
     for (var securityHotspotNode : nonFilteredNodes) {
       if (filter.shouldIncludeSecurityHotspot(securityHotspotNode.getHotspot())) {
@@ -256,27 +279,30 @@ public class SecurityHotspotTreeModelBuilder implements FindingTreeModelBuilder 
         var newIdx = new int[] {idx};
         model.nodesWereInserted(summary, newIdx);
         model.nodeChanged(summary);
-        currentlyFilteredCount++;
+        filteredNodes.add(securityHotspotNode);
       }
     }
 
     model.reload();
-    filteredCount = currentlyFilteredCount;
-    return filteredCount;
+    return filteredNodes.size();
   }
 
   public void clear() {
     updateModel(Collections.emptyMap(), "No analysis done");
   }
 
-  private static List<LiveSecurityHotspot> filter(Iterable<LiveSecurityHotspot> securityHotspots) {
+  private static List<LiveSecurityHotspot> filter(Iterable<LiveSecurityHotspot> securityHotspots, boolean enableResolved) {
     return StreamSupport.stream(securityHotspots.spliterator(), false)
-      .filter(SecurityHotspotTreeModelBuilder::accept)
+      .filter(hotspot -> accept(hotspot, enableResolved))
       .collect(Collectors.toList());
   }
 
-  private static boolean accept(LiveSecurityHotspot securityHotspot) {
-    return securityHotspot.isValid();
+  private static boolean accept(LiveSecurityHotspot securityHotspot, boolean enableResolved) {
+    if (enableResolved) {
+      return securityHotspot.isValid();
+    } else {
+      return !securityHotspot.isResolved() && securityHotspot.isValid();
+    }
   }
 
   private static boolean accept(VirtualFile file) {

--- a/src/test/java/org/sonarlint/intellij/ui/tree/SecurityHotspotTreeModelBuilderTests.java
+++ b/src/test/java/org/sonarlint/intellij/ui/tree/SecurityHotspotTreeModelBuilderTests.java
@@ -21,6 +21,7 @@ package org.sonarlint.intellij.ui.tree;
 
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.RangeMarker;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import java.util.ArrayList;
@@ -54,6 +55,7 @@ class SecurityHotspotTreeModelBuilderTests {
 
   private SecurityHotspotTreeModelBuilder treeBuilder;
   private DefaultTreeModel model;
+  private Project project = mock(Project.class);
 
   @BeforeEach
   void init() {
@@ -139,13 +141,13 @@ class SecurityHotspotTreeModelBuilderTests {
 
     treeBuilder.updateModelWithoutFileNode(data, "empty");
 
-    assertThat(treeBuilder.filterSecurityHotspots(SecurityHotspotFilters.SHOW_ALL)).isEqualTo(3);
+    assertThat(treeBuilder.filterSecurityHotspots(project, SecurityHotspotFilters.SHOW_ALL)).isEqualTo(3);
     assertThat(treeBuilder.getFilteredNodes()).hasSize(3);
 
-    assertThat(treeBuilder.filterSecurityHotspots(SecurityHotspotFilters.EXISTING_ON_SONARQUBE)).isEqualTo(2);
+    assertThat(treeBuilder.filterSecurityHotspots(project, SecurityHotspotFilters.EXISTING_ON_SONARQUBE)).isEqualTo(2);
     assertThat(treeBuilder.getFilteredNodes()).hasSize(2);
 
-    assertThat(treeBuilder.filterSecurityHotspots(SecurityHotspotFilters.LOCAL_ONLY)).isEqualTo(1);
+    assertThat(treeBuilder.filterSecurityHotspots(project, SecurityHotspotFilters.LOCAL_ONLY)).isEqualTo(1);
     assertThat(treeBuilder.getFilteredNodes()).hasSize(1);
   }
 
@@ -161,11 +163,11 @@ class SecurityHotspotTreeModelBuilderTests {
     treeBuilder.updateModelWithoutFileNode(data, "empty");
 
     FilterSecurityHotspotSettings.setResolved(false);
-    assertThat(treeBuilder.filterSecurityHotspots(SecurityHotspotFilters.SHOW_ALL)).isEqualTo(2);
+    assertThat(treeBuilder.filterSecurityHotspots(project, SecurityHotspotFilters.SHOW_ALL)).isEqualTo(2);
     assertThat(treeBuilder.getFilteredNodes()).hasSize(2);
 
     FilterSecurityHotspotSettings.setResolved(true);
-    assertThat(treeBuilder.filterSecurityHotspots(SecurityHotspotFilters.SHOW_ALL)).isEqualTo(4);
+    assertThat(treeBuilder.filterSecurityHotspots(project, SecurityHotspotFilters.SHOW_ALL)).isEqualTo(4);
     assertThat(treeBuilder.getFilteredNodes()).hasSize(4);
   }
 

--- a/src/test/java/org/sonarlint/intellij/ui/tree/SecurityHotspotTreeModelBuilderTests.java
+++ b/src/test/java/org/sonarlint/intellij/ui/tree/SecurityHotspotTreeModelBuilderTests.java
@@ -21,7 +21,6 @@ package org.sonarlint.intellij.ui.tree;
 
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.RangeMarker;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import java.util.ArrayList;
@@ -36,8 +35,10 @@ import javax.annotation.Nullable;
 import javax.swing.tree.DefaultTreeModel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.sonarlint.intellij.AbstractSonarLintLightTests;
 import org.sonarlint.intellij.actions.filters.FilterSecurityHotspotSettings;
 import org.sonarlint.intellij.actions.filters.SecurityHotspotFilters;
+import org.sonarlint.intellij.editor.CodeAnalyzerRestarter;
 import org.sonarlint.intellij.finding.hotspot.LiveSecurityHotspot;
 import org.sonarlint.intellij.ui.nodes.AbstractNode;
 import org.sonarlint.intellij.ui.nodes.LiveSecurityHotspotNode;
@@ -51,11 +52,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class SecurityHotspotTreeModelBuilderTests {
+class SecurityHotspotTreeModelBuilderTests extends AbstractSonarLintLightTests {
 
+  private final CodeAnalyzerRestarter codeAnalyzerRestarter = mock(CodeAnalyzerRestarter.class);
   private SecurityHotspotTreeModelBuilder treeBuilder;
   private DefaultTreeModel model;
-  private Project project = mock(Project.class);
 
   @BeforeEach
   void init() {
@@ -63,6 +64,7 @@ class SecurityHotspotTreeModelBuilderTests {
     model = treeBuilder.createModel();
     FilterSecurityHotspotSettings.setCurrentlySelectedFilter(SecurityHotspotFilters.DEFAULT_FILTER);
     FilterSecurityHotspotSettings.setResolved(false);
+    replaceProjectService(CodeAnalyzerRestarter.class, codeAnalyzerRestarter);
   }
 
   @Test
@@ -141,13 +143,13 @@ class SecurityHotspotTreeModelBuilderTests {
 
     treeBuilder.updateModelWithoutFileNode(data, "empty");
 
-    assertThat(treeBuilder.filterSecurityHotspots(project, SecurityHotspotFilters.SHOW_ALL)).isEqualTo(3);
+    assertThat(treeBuilder.filterSecurityHotspots(getProject(), SecurityHotspotFilters.SHOW_ALL)).isEqualTo(3);
     assertThat(treeBuilder.getFilteredNodes()).hasSize(3);
 
-    assertThat(treeBuilder.filterSecurityHotspots(project, SecurityHotspotFilters.EXISTING_ON_SONARQUBE)).isEqualTo(2);
+    assertThat(treeBuilder.filterSecurityHotspots(getProject(), SecurityHotspotFilters.EXISTING_ON_SONARQUBE)).isEqualTo(2);
     assertThat(treeBuilder.getFilteredNodes()).hasSize(2);
 
-    assertThat(treeBuilder.filterSecurityHotspots(project, SecurityHotspotFilters.LOCAL_ONLY)).isEqualTo(1);
+    assertThat(treeBuilder.filterSecurityHotspots(getProject(), SecurityHotspotFilters.LOCAL_ONLY)).isEqualTo(1);
     assertThat(treeBuilder.getFilteredNodes()).hasSize(1);
   }
 
@@ -163,11 +165,11 @@ class SecurityHotspotTreeModelBuilderTests {
     treeBuilder.updateModelWithoutFileNode(data, "empty");
 
     FilterSecurityHotspotSettings.setResolved(false);
-    assertThat(treeBuilder.filterSecurityHotspots(project, SecurityHotspotFilters.SHOW_ALL)).isEqualTo(2);
+    assertThat(treeBuilder.filterSecurityHotspots(getProject(), SecurityHotspotFilters.SHOW_ALL)).isEqualTo(2);
     assertThat(treeBuilder.getFilteredNodes()).hasSize(2);
 
     FilterSecurityHotspotSettings.setResolved(true);
-    assertThat(treeBuilder.filterSecurityHotspots(project, SecurityHotspotFilters.SHOW_ALL)).isEqualTo(4);
+    assertThat(treeBuilder.filterSecurityHotspots(getProject(), SecurityHotspotFilters.SHOW_ALL)).isEqualTo(4);
     assertThat(treeBuilder.getFilteredNodes()).hasSize(4);
   }
 

--- a/src/test/java/org/sonarlint/intellij/ui/tree/SecurityHotspotTreeModelBuilderTests.java
+++ b/src/test/java/org/sonarlint/intellij/ui/tree/SecurityHotspotTreeModelBuilderTests.java
@@ -140,8 +140,13 @@ class SecurityHotspotTreeModelBuilderTests {
     treeBuilder.updateModelWithoutFileNode(data, "empty");
 
     assertThat(treeBuilder.filterSecurityHotspots(SecurityHotspotFilters.SHOW_ALL)).isEqualTo(3);
+    assertThat(treeBuilder.getFilteredNodes()).hasSize(3);
+
     assertThat(treeBuilder.filterSecurityHotspots(SecurityHotspotFilters.EXISTING_ON_SONARQUBE)).isEqualTo(2);
+    assertThat(treeBuilder.getFilteredNodes()).hasSize(2);
+
     assertThat(treeBuilder.filterSecurityHotspots(SecurityHotspotFilters.LOCAL_ONLY)).isEqualTo(1);
+    assertThat(treeBuilder.getFilteredNodes()).hasSize(1);
   }
 
   @Test
@@ -157,8 +162,11 @@ class SecurityHotspotTreeModelBuilderTests {
 
     FilterSecurityHotspotSettings.setResolved(false);
     assertThat(treeBuilder.filterSecurityHotspots(SecurityHotspotFilters.SHOW_ALL)).isEqualTo(2);
+    assertThat(treeBuilder.getFilteredNodes()).hasSize(2);
+
     FilterSecurityHotspotSettings.setResolved(true);
     assertThat(treeBuilder.filterSecurityHotspots(SecurityHotspotFilters.SHOW_ALL)).isEqualTo(4);
+    assertThat(treeBuilder.getFilteredNodes()).hasSize(4);
   }
 
   private void addFile(Map<VirtualFile, Collection<LiveSecurityHotspot>> data, String fileName, int numSecurityHotspots) {
@@ -181,7 +189,6 @@ class SecurityHotspotTreeModelBuilderTests {
         securityHotspotList.add(mockSecurityHotspot(fileName, i, "rule" + i, VulnerabilityProbability.HIGH, (long) i, status, serverFindingKey + "" + (i + 1)));
       } else {
         securityHotspotList.add(mockSecurityHotspot(fileName, i, "rule" + i, VulnerabilityProbability.HIGH, (long) i, status, null));
-
       }
     }
 


### PR DESCRIPTION
- Hide resolved security hotspots from the report tab
- Fix the status not being selected rightfully when updating from the report tab
- Only highlight security hotspot that are currently displayed in the security hotspot tab list
- Fix filtering when status is not supported
- Trigger highlighting on filter change