### PR TITLE
SLI-921: Theme changes in rule description

### DIFF
--- a/src/main/java/org/sonarlint/intellij/ui/AbstractIssuesPanel.java
+++ b/src/main/java/org/sonarlint/intellij/ui/AbstractIssuesPanel.java
@@ -20,11 +20,14 @@
 package org.sonarlint.intellij.ui;
 
 import com.intellij.ide.OccurenceNavigator;
+import com.intellij.ide.ui.LafManager;
+import com.intellij.ide.ui.LafManagerListener;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.ActionGroup;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.ActionToolbar;
 import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
@@ -94,7 +97,17 @@ public abstract class AbstractIssuesPanel extends SimpleToolWindowPanel implemen
     detailsTab.insertTab("Locations", null, flowsPanel, "All locations involved in the issue", LOCATIONS_TAB_INDEX);
   }
 
+  /**
+   *  To handle UI theme changes the rule windows must be reloaded immediately, otherwise the accessibility isn't great
+   *  (bad contrast, ...). We want to subscribe to the message bus everytime the rule panel content changes to reload
+   *  the panel with the correct rule content.
+   */
   protected void issueTreeSelectionChanged() {
+    ApplicationManager.getApplication().getMessageBus().connect().subscribe(LafManagerListener.TOPIC, ignored -> actualIssueTreeSelectionChanged());
+    actualIssueTreeSelectionChanged();
+  }
+
+  private void actualIssueTreeSelectionChanged() {
     var selectedNodes = tree.getSelectedNodes(IssueNode.class, null);
     if (selectedNodes.length > 0) {
       var issue = selectedNodes[0].issue();

--- a/src/main/java/org/sonarlint/intellij/ui/ReportPanel.java
+++ b/src/main/java/org/sonarlint/intellij/ui/ReportPanel.java
@@ -19,10 +19,12 @@
  */
 package org.sonarlint.intellij.ui;
 
+import com.intellij.ide.ui.LafManagerListener;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.ActionGroup;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.ActionToolbar;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
@@ -141,7 +143,17 @@ public class ReportPanel extends SimpleToolWindowPanel implements Disposable {
     securityHotspotTree.setVisible(false);
   }
 
+  /**
+   *  To handle UI theme changes the rule windows must be reloaded immediately, otherwise the accessibility isn't great
+   *  (bad contrast, ...). We want to subscribe to the message bus everytime the rule panel content changes to reload
+   *  the panel with the correct rule content.
+   */
   private void issueTreeSelectionChanged(TreeSelectionEvent e) {
+    ApplicationManager.getApplication().getMessageBus().connect().subscribe(LafManagerListener.TOPIC, ignored -> actualIssueTreeSelectionChanged());
+    actualIssueTreeSelectionChanged();
+  }
+
+  private void actualIssueTreeSelectionChanged() {
     if (!tree.isSelectionEmpty()) {
       securityHotspotTree.clearSelection();
     }
@@ -153,7 +165,17 @@ public class ReportPanel extends SimpleToolWindowPanel implements Disposable {
     }
   }
 
+  /**
+   *  To handle UI theme changes the rule windows must be reloaded immediately, otherwise the accessibility isn't great
+   *  (bad contrast, ...). We want to subscribe to the message bus everytime the rule panel content changes to reload
+   *  the panel with the correct rule content.
+   */
   private void securityHotspotTreeSelectionChanged(TreeSelectionEvent e) {
+    ApplicationManager.getApplication().getMessageBus().connect().subscribe(LafManagerListener.TOPIC, ignored -> actualSecurityHotspotTreeSelectionChanged(e));
+    actualSecurityHotspotTreeSelectionChanged(e);
+  }
+
+  private void actualSecurityHotspotTreeSelectionChanged(TreeSelectionEvent e) {
     if (e.getSource() instanceof SecurityHotspotTree) {
       if (!securityHotspotTree.isSelectionEmpty()) {
         tree.clearSelection();

--- a/src/main/java/org/sonarlint/intellij/ui/SecurityHotspotsPanel.java
+++ b/src/main/java/org/sonarlint/intellij/ui/SecurityHotspotsPanel.java
@@ -19,10 +19,12 @@
  */
 package org.sonarlint.intellij.ui;
 
+import com.intellij.ide.ui.LafManagerListener;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.ActionGroup;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.ActionToolbar;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
@@ -187,7 +189,17 @@ public class SecurityHotspotsPanel extends SimpleToolWindowPanel implements Disp
     tree.getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
   }
 
+  /**
+   *  To handle UI theme changes the rule windows must be reloaded immediately, otherwise the accessibility isn't great
+   *  (bad contrast, ...). We want to subscribe to the message bus everytime the rule panel content changes to reload
+   *  the panel with the correct rule content.
+   */
   private void securityHotspotTreeSelectionChanged(TreeSelectionEvent e) {
+    ApplicationManager.getApplication().getMessageBus().connect().subscribe(LafManagerListener.TOPIC, ignored -> actualSecurityHotspotTreeSelectionChanged(e));
+    actualSecurityHotspotTreeSelectionChanged(e);
+  }
+
+  private void actualSecurityHotspotTreeSelectionChanged(TreeSelectionEvent e) {
     if (e.getSource() instanceof SecurityHotspotTree) {
       var selectedHotspotsNodes = securityHotspotTree.getSelectedNodes(LiveSecurityHotspotNode.class, null);
       if (selectedHotspotsNodes.length > 0) {


### PR DESCRIPTION
## Summary

When changing the theme (Look And Feel) the rule description window refreshes to show the content correctly. This will also work with every other change to the UI (e.g. accessability).

## Testing

Testing was done manually, on macOS there is a slight "lag", so please test it on Linux to check if it's only a macOS thing ^^