### PR TITLE
SLI-936: Update Java analyzer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -203,7 +203,7 @@ dependencies {
     testImplementation("org.eclipse.jetty:jetty-server:$jettyVersion")
     testImplementation("org.eclipse.jetty:jetty-servlet:$jettyVersion")
     testImplementation("org.eclipse.jetty:jetty-proxy:$jettyVersion")
-    "sqplugins"("org.sonarsource.java:sonar-java-plugin:7.18.0.31443")
+    "sqplugins"("org.sonarsource.java:sonar-java-plugin:7.19.0.31550")
     "sqplugins"("org.sonarsource.javascript:sonar-javascript-plugin:10.2.0.21568")
     "sqplugins"("org.sonarsource.php:sonar-php-plugin:3.29.0.9684")
     "sqplugins"("org.sonarsource.python:sonar-python-plugin:4.3.0.11660")

--- a/src/main/java/org/sonarlint/intellij/java/JavaAnalysisConfigurator.java
+++ b/src/main/java/org/sonarlint/intellij/java/JavaAnalysisConfigurator.java
@@ -66,6 +66,7 @@ public class JavaAnalysisConfigurator implements AnalysisConfigurator {
   private static final String JAVA_TEST_LIBRARIES_PROPERTY = "sonar.java.test.libraries";
   private static final String JAVA_TEST_BINARIES_PROPERTY = "sonar.java.test.binaries";
   private static final String JAVA_JDK_HOME_PROPERTY = "sonar.java.jdkHome";
+  private static final String JAVA_ENABLE_PREVIEW = "sonar.java.enablePreview";
 
   private static final char SEPARATOR = ',';
 
@@ -110,6 +111,7 @@ public class JavaAnalysisConfigurator implements AnalysisConfigurator {
     }
     properties.put(JAVA_SOURCE_PROPERTY, languageLevelStr);
     properties.put(JAVA_TARGET_PROPERTY, bytecodeTarget);
+    properties.put(JAVA_ENABLE_PREVIEW, String.valueOf(languageLevel.isPreview()));
   }
 
   private static String getLanguageLevelOption(LanguageLevel level) {

--- a/src/test/java/org/sonarlint/intellij/analysis/JavaAnalysisConfiguratorInvalidEntryTests.java
+++ b/src/test/java/org/sonarlint/intellij/analysis/JavaAnalysisConfiguratorInvalidEntryTests.java
@@ -58,7 +58,7 @@ class JavaAnalysisConfiguratorInvalidEntryTests extends AbstractSonarLintLightTe
   @Test
   void testClasspathIgnoreInvalidJdkEntries() {
     final var props = underTest.configure(getModule(), Collections.emptyList()).extraProperties;
-    assertThat(props).containsOnlyKeys("sonar.java.source", "sonar.java.target");
+    assertThat(props).containsOnlyKeys("sonar.java.source", "sonar.java.target", "sonar.java.enablePreview");
   }
 
 }

--- a/src/test/java/org/sonarlint/intellij/analysis/JavaAnalysisConfiguratorTests.java
+++ b/src/test/java/org/sonarlint/intellij/analysis/JavaAnalysisConfiguratorTests.java
@@ -188,6 +188,18 @@ class JavaAnalysisConfiguratorTests extends AbstractSonarLintLightTests {
     assertThat(underTest.configure(getModule(), Collections.emptyList()).extraProperties).contains(entry("sonar.java.source", "9"), entry("sonar.java.target", "9"));
   }
 
+  /** SLI-936: Property "sonar.java.enablePreview" not set automatically anymore but based on module configuration */
+  @Test
+  void test_enablePreview() {
+    IdeaTestUtil.setModuleLanguageLevel(getModule(), LanguageLevel.JDK_17);
+    assertThat(underTest.configure(getModule(), Collections.emptyList()).extraProperties)
+            .contains(entry("sonar.java.enablePreview", "false"));
+
+    IdeaTestUtil.setModuleLanguageLevel(getModule(), LanguageLevel.JDK_17_PREVIEW);
+    assertThat(underTest.configure(getModule(), Collections.emptyList()).extraProperties)
+            .contains(entry("sonar.java.enablePreview", "true"));
+  }
+
   @Test
   void testSourceAndTarget_with_different_target() {
     IdeaTestUtil.setModuleLanguageLevel(getModule(), LanguageLevel.JDK_1_8);


### PR DESCRIPTION
Java analyzer update and logical change regarding the `sonar.java.enablePreview` property.