### PR TITLE
SLI-833: Reworked the former solution

### DIFF
--- a/src/main/java/org/sonarlint/intellij/util/SonarLintAppUtils.java
+++ b/src/main/java/org/sonarlint/intellij/util/SonarLintAppUtils.java
@@ -134,18 +134,21 @@ public class SonarLintAppUtils {
    */
   @CheckForNull
   private static String getPathRelativeToModuleBaseDir(Module module, VirtualFile file) {
+    var filePath = Paths.get(file.getPath());
     var moduleContentRoots = Arrays.stream(ModuleRootManager.getInstance(module).getContentRoots())
             .filter(contentRoot -> contentRoot.getPath().trim().length() > 0)
             .toArray(VirtualFile[]::new);
 
-    // If there are multiple content roots (this can be possible based on the SDK API documentation), just take the
-    // first one, assuming this one is the path of the ".iml" file.
-    var baseDir = Paths.get(moduleContentRoots[0].getPath()).getParent();
-    var filePath = Paths.get(file.getPath());
-    if (!filePath.startsWith(baseDir)) {
-      return null;
+    // There can be multiple content roots (based on the IntelliJ SDK), e.g. for a Gradle project the project directory
+    // and every sourceSet (main, test, ...) or based on the .idea/modules.xml configuration.
+    for (VirtualFile contentRoot: moduleContentRoots) {
+      var contentRootDir = Paths.get(contentRoot.getPath());
+      if (filePath.startsWith(contentRootDir)) {
+        return PathUtil.toSystemIndependentName(contentRootDir.relativize(filePath).toString());
+      }
     }
-    return PathUtil.toSystemIndependentName(baseDir.relativize(filePath).toString());
+
+    return null;
   }
 
   @CheckForNull

--- a/src/main/java/org/sonarlint/intellij/util/SonarLintAppUtils.java
+++ b/src/main/java/org/sonarlint/intellij/util/SonarLintAppUtils.java
@@ -131,9 +131,14 @@ public class SonarLintAppUtils {
   /**
    *  Path will always contain forward slashes. Resolving the module path uses the official alternative to
    *  {@link com.intellij.openapi.module.Module#getModuleFilePath} which is marked as internally!
+   *
+   *  INFO: Package level access for the light / heavy testing as manipulating
+   *  {@link com.intellij.testFramework.fixtures.BasePlatformTestCase} for
+   *  {@link SonarLintAppUtils#getRelativePathForAnalysis} to not return from
+   *  {@link SonarLintAppUtils#getPathRelativeToProjectBaseDir} every time would be way too time-consuming!
    */
   @CheckForNull
-  private static String getPathRelativeToModuleBaseDir(Module module, VirtualFile file) {
+  static String getPathRelativeToModuleBaseDir(Module module, VirtualFile file) {
     var filePath = Paths.get(file.getPath());
     var moduleContentRoots = Arrays.stream(ModuleRootManager.getInstance(module).getContentRoots())
             .filter(contentRoot -> contentRoot.getPath().trim().length() > 0)

--- a/src/test/java/org/sonarlint/intellij/util/SonarLintAppUtilsHeavyTests.kt
+++ b/src/test/java/org/sonarlint/intellij/util/SonarLintAppUtilsHeavyTests.kt
@@ -1,0 +1,58 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) 2015-2023 SonarSource
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.util
+
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.application
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.sonarlint.intellij.AbstractSonarLintHeavyTests
+
+/** Heavy tests on [org.sonarlint.intellij.util.SonarLintAppUtils] */
+class SonarLintAppUtilsHeavyTests : AbstractSonarLintHeavyTests() {
+    /** SLI-833: Test case 3: Only one module with multiple content roots */
+    @Test
+    fun test_getPathRelativeToModuleBaseDir_multipleModuleContentRoots() {
+        lateinit var contentRoot1File: VirtualFile
+        lateinit var contentRoot2File: VirtualFile
+
+        val multiContentRootModule = createModule("SLI-833")
+
+        val contentRoot1 = createTestProjectStructure()
+        val contentRoot2 = createTestProjectStructure()
+        ModuleRootModificationUtil.addContentRoot(multiContentRootModule, contentRoot1)
+        ModuleRootModificationUtil.addContentRoot(multiContentRootModule, contentRoot2)
+
+        application.runWriteAction {
+            val contentRoot1Directory = contentRoot1.createChildDirectory(project, "src")
+            contentRoot1File = contentRoot1Directory.createChildData(project, "Dummy.kt")
+
+            val contentRoot2Directory = contentRoot2.createChildDirectory(project, "test")
+            contentRoot2File = contentRoot2Directory.createChildData(project, "DummyTest.kt")
+        }
+
+        // Due to the content roots not being sorted we just test for both content roots
+        assertThat(SonarLintAppUtils.getPathRelativeToModuleBaseDir(multiContentRootModule, contentRoot1File))
+            .isEqualTo("src/Dummy.kt")
+        assertThat(SonarLintAppUtils.getPathRelativeToModuleBaseDir(multiContentRootModule, contentRoot2File))
+            .isEqualTo("test/DummyTest.kt")
+    }
+}

--- a/src/test/java/org/sonarlint/intellij/util/SonarLintAppUtilsLightTests.kt
+++ b/src/test/java/org/sonarlint/intellij/util/SonarLintAppUtilsLightTests.kt
@@ -1,0 +1,43 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) 2015-2023 SonarSource
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.sonarlint.intellij.AbstractSonarLintLightTests
+
+/** Light tests on [org.sonarlint.intellij.util.SonarLintAppUtils] */
+class SonarLintAppUtilsLightTests : AbstractSonarLintLightTests() {
+    /** SLI-833: Test case 1: Only one module */
+    @Test
+    fun test_getPathRelativeToModuleBaseDir_oneModuleContentRoot() {
+        val directory = myFixture.copyDirectoryToProject("src", "src")
+        assertThat(SonarLintAppUtils.getPathRelativeToModuleBaseDir(module, directory.findChild("Dummy.kt")!!))
+            .isEqualTo("src/Dummy.kt")
+    }
+
+    /** SLI-833: Test case 2: Only one module but the requested file resides outside of module */
+    @Test
+    fun test_getPathRelativeToModuleBaseDir_oneModuleContentRoot_wrongFile() {
+        val directory = myFixture.copyDirectoryToProject("src", "src")
+        assertThat(SonarLintAppUtils.getPathRelativeToModuleBaseDir(module, directory.parent.parent))
+            .isEqualTo(null)
+    }
+}

--- a/src/test/java/org/sonarlint/intellij/util/SonarLintAppUtilsTests.java
+++ b/src/test/java/org/sonarlint/intellij/util/SonarLintAppUtilsTests.java
@@ -1,0 +1,7 @@
+package org.sonarlint.intellij.util;
+
+import org.sonarlint.intellij.AbstractSonarLintLightTests;
+
+public class SonarLintAppUtilsTests extends AbstractSonarLintLightTests {
+    /* NOT YET IMPLEMENTED */
+}

--- a/src/test/java/org/sonarlint/intellij/util/SonarLintAppUtilsTests.java
+++ b/src/test/java/org/sonarlint/intellij/util/SonarLintAppUtilsTests.java
@@ -1,7 +1,0 @@
-package org.sonarlint.intellij.util;
-
-import org.sonarlint.intellij.AbstractSonarLintLightTests;
-
-public class SonarLintAppUtilsTests extends AbstractSonarLintLightTests {
-    /* NOT YET IMPLEMENTED */
-}


### PR DESCRIPTION
## Summary

Minor changes to the former solution to check for all module content roots and not the first one. Checking every content root is necessary when for example a source folder is outside of the main project, this can be achieved with Gradle very easily. The other option is to have a project span multiple drives in Windows (I have no idea why anybody should do that, but okey).

## Testing

To test the easiest case (file inside module with one content root) and the second easiest case (file outside module with one content root) are implemented as light tests. The *corner case* test (file inside module with multiple content roots not connected to one another) was implemented as a heavy test, as `com.intellij.testFramework.HeavyPlatformTestCase` provides the best way to create a standalone module with multiple content roots.