### PR TITLE
SLI-958 Wait for server findings

### DIFF
--- a/src/main/java/org/sonarlint/intellij/actions/SonarCancelAction.java
+++ b/src/main/java/org/sonarlint/intellij/actions/SonarCancelAction.java
@@ -22,6 +22,8 @@ package org.sonarlint.intellij.actions;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import org.sonarlint.intellij.analysis.AnalysisStatus;
+import org.sonarlint.intellij.analysis.AnalysisSubmitter;
+import org.sonarlint.intellij.common.util.SonarLintUtils;
 
 public class SonarCancelAction extends AbstractSonarAction {
   @Override
@@ -33,6 +35,7 @@ public class SonarCancelAction extends AbstractSonarAction {
   public void actionPerformed(AnActionEvent e) {
     if (e.getProject() != null) {
       AnalysisStatus.get(e.getProject()).cancel();
+      SonarLintUtils.getService(e.getProject(), AnalysisSubmitter.class).cancelCurrentAutoAnalysis();
     }
   }
 }

--- a/src/main/java/org/sonarlint/intellij/actions/SonarCancelAction.java
+++ b/src/main/java/org/sonarlint/intellij/actions/SonarCancelAction.java
@@ -35,7 +35,7 @@ public class SonarCancelAction extends AbstractSonarAction {
   public void actionPerformed(AnActionEvent e) {
     if (e.getProject() != null) {
       AnalysisStatus.get(e.getProject()).cancel();
-      SonarLintUtils.getService(e.getProject(), AnalysisSubmitter.class).cancelCurrentAutoAnalysis();
+      SonarLintUtils.getService(e.getProject(), AnalysisSubmitter.class).cancelCurrentManualAnalysis();
     }
   }
 }

--- a/src/main/java/org/sonarlint/intellij/analysis/Analysis.java
+++ b/src/main/java/org/sonarlint/intellij/analysis/Analysis.java
@@ -62,17 +62,14 @@ public class Analysis implements Cancelable {
   private final Project project;
   private final Collection<VirtualFile> files;
   private final TriggerType trigger;
-  private final boolean waitForServerFindings;
   private final AnalysisCallback callback;
   private boolean finished = false;
   private boolean cancelled;
 
-  public Analysis(Project project, Collection<VirtualFile> files, TriggerType trigger, boolean waitForServerFindings,
-    AnalysisCallback callback) {
+  public Analysis(Project project, Collection<VirtualFile> files, TriggerType trigger, AnalysisCallback callback) {
     this.project = project;
     this.files = files;
     this.trigger = trigger;
-    this.waitForServerFindings = waitForServerFindings;
     this.callback = callback;
   }
 
@@ -158,7 +155,7 @@ public class Analysis implements Cancelable {
     if (!filesHavingIssuesByModule.isEmpty()) {
       var serverIssueUpdater = SonarLintUtils.getService(project, ServerIssueUpdater.class);
       if (trigger.isShouldUpdateServerIssues()) {
-        serverIssueUpdater.fetchAndMatchServerIssues(filesHavingIssuesByModule, indicator, waitForServerFindings);
+        serverIssueUpdater.fetchAndMatchServerIssues(filesHavingIssuesByModule, indicator);
       } else {
         serverIssueUpdater.matchServerIssues(filesHavingIssuesByModule);
       }
@@ -170,7 +167,7 @@ public class Analysis implements Cancelable {
     if (!filesHavingSecurityHotspotsByModule.isEmpty()) {
       var updater = SonarLintUtils.getService(project, ServerSecurityHotspotUpdater.class);
       if (trigger.isShouldUpdateServerIssues()) {
-        updater.fetchAndMatchServerSecurityHotspots(filesHavingSecurityHotspotsByModule, indicator, waitForServerFindings);
+        updater.fetchAndMatchServerSecurityHotspots(filesHavingSecurityHotspotsByModule, indicator);
       } else {
         updater.matchServerSecurityHotspots(filesHavingSecurityHotspotsByModule);
       }

--- a/src/main/java/org/sonarlint/intellij/analysis/Analysis.java
+++ b/src/main/java/org/sonarlint/intellij/analysis/Analysis.java
@@ -65,6 +65,7 @@ public class Analysis implements Cancelable {
   private final AnalysisCallback callback;
   private boolean finished = false;
   private boolean cancelled;
+  private ProgressIndicator indicator;
 
   public Analysis(Project project, Collection<VirtualFile> files, TriggerType trigger, AnalysisCallback callback) {
     this.project = project;
@@ -73,13 +74,15 @@ public class Analysis implements Cancelable {
     this.callback = callback;
   }
 
-
   public AnalysisResult run(ProgressIndicator indicator) {
     try {
+      finished = false;
+      this.indicator = indicator;
       notifyStart();
       return doRun(indicator);
     } finally {
       finished = true;
+      this.indicator = null;
       if (!project.isDisposed()) {
         getService(project, AnalysisStatus.class).stopRun();
       }
@@ -94,6 +97,9 @@ public class Analysis implements Cancelable {
   public void cancel() {
     if (!isFinished()) {
       this.cancelled = true;
+      if (indicator != null) {
+        indicator.cancel();
+      }
     }
   }
 
@@ -137,7 +143,9 @@ public class Analysis implements Cancelable {
 
       findingsCache.replaceFindings(summary.findings);
 
+      checkCanceled(indicator);
       matchWithServerIssuesIfNeeded(indicator, summary.filesHavingIssuesByModule);
+      checkCanceled(indicator);
       matchWithServerSecurityHotspotsIfNeeded(indicator, summary.filesHavingSecurityHotspotsByModule);
 
       var result = new AnalysisResult(summary.findings, files, trigger, Instant.now());
@@ -229,8 +237,7 @@ public class Analysis implements Cancelable {
     return new Summary(project, scope.getFilesByModule(), allFailedFiles, rawFindingHandler.getRawIssueCount(), findings);
   }
 
-  private static <T> Map<VirtualFile, Collection<T>> getFindingsPerAnalyzedFile(Map<VirtualFile,
-    Collection<T>> detectedFindingsPerFile, Set<VirtualFile> analyzedFiles) {
+  private static <T> Map<VirtualFile, Collection<T>> getFindingsPerAnalyzedFile(Map<VirtualFile, Collection<T>> detectedFindingsPerFile, Set<VirtualFile> analyzedFiles) {
     Map<VirtualFile, Collection<T>> findingsPerAnalyzedFile = analyzedFiles.stream().collect(toMap(Function.identity(),
       k -> new ArrayList<>()));
     findingsPerAnalyzedFile.putAll(detectedFindingsPerFile);
@@ -265,13 +272,12 @@ public class Analysis implements Cancelable {
       this.onlyFailedFiles = failedFiles.containsAll(filesByModule.values().stream().flatMap(Collection::stream).collect(toSet()));
     }
 
-    private static <L extends LiveFinding> Map<Module, Collection<VirtualFile>> filterFilesHavingFindingsByModule(Map<Module,
-      Collection<VirtualFile>> filesByModule, Map<VirtualFile, Collection<L>> issuesPerFile) {
+    private static <L extends LiveFinding> Map<Module, Collection<VirtualFile>> filterFilesHavingFindingsByModule(Map<Module, Collection<VirtualFile>> filesByModule,
+      Map<VirtualFile, Collection<L>> issuesPerFile) {
       var filesWithIssuesPerModule = new LinkedHashMap<Module, Collection<VirtualFile>>();
 
       for (var entry : filesByModule.entrySet()) {
-        var moduleFilesWithIssues =
-          entry.getValue().stream().filter(f -> !issuesPerFile.getOrDefault(f, Collections.emptyList()).isEmpty()).collect(toList());
+        var moduleFilesWithIssues = entry.getValue().stream().filter(f -> !issuesPerFile.getOrDefault(f, Collections.emptyList()).isEmpty()).collect(toList());
         if (!moduleFilesWithIssues.isEmpty()) {
           filesWithIssuesPerModule.put(entry.getKey(), moduleFilesWithIssues);
         }

--- a/src/main/java/org/sonarlint/intellij/analysis/AnalysisSubmitter.java
+++ b/src/main/java/org/sonarlint/intellij/analysis/AnalysisSubmitter.java
@@ -49,17 +49,17 @@ public final class AnalysisSubmitter {
   public static final String ANALYSIS_TASK_TITLE = "SonarLint Analysis";
   private final Project project;
   private final OnTheFlyFindingsHolder onTheFlyFindingsHolder;
-  private Analysis currentAutoAnalysis;
+  private Cancelable currentManualAnalysis;
 
   public AnalysisSubmitter(Project project) {
     this.project = project;
     this.onTheFlyFindingsHolder = new OnTheFlyFindingsHolder(project);
   }
 
-  public void cancelCurrentAutoAnalysis() {
-    if (currentAutoAnalysis != null) {
-      currentAutoAnalysis.cancel();
-      currentAutoAnalysis = null;
+  public void cancelCurrentManualAnalysis() {
+    if (currentManualAnalysis != null) {
+      currentManualAnalysis.cancel();
+      currentManualAnalysis = null;
     }
   }
 
@@ -124,7 +124,7 @@ public final class AnalysisSubmitter {
     if (shouldExecuteInBackground(actionEvent)) {
       analyzeInBackground(files, TriggerType.ACTION, callback);
     } else {
-      analyzeInBackgroundableModal(files, TriggerType.ACTION, callback);
+      currentManualAnalysis = analyzeInBackgroundableModal(files, TriggerType.ACTION, callback);
     }
   }
 
@@ -147,20 +147,18 @@ public final class AnalysisSubmitter {
   }
 
   private Cancelable analyzeInBackground(Collection<VirtualFile> files, TriggerType trigger, AnalysisCallback callback) {
+    var analysis = new Analysis(project, files, trigger, callback);
+    TaskRunnerKt.startBackgroundTask(project, ANALYSIS_TASK_TITLE, analysis::run);
+    return analysis;
+  }
+
+  private Cancelable analyzeInBackgroundableModal(Collection<VirtualFile> files, TriggerType action, AnalysisCallback callback) {
     if (shouldSkipAnalysis()) {
       return null;
     }
-    currentAutoAnalysis = new Analysis(project, files, trigger, callback);
-    TaskRunnerKt.startBackgroundTask(project, ANALYSIS_TASK_TITLE, currentAutoAnalysis::run);
-    return currentAutoAnalysis;
-  }
-
-  private void analyzeInBackgroundableModal(Collection<VirtualFile> files, TriggerType action, AnalysisCallback callback) {
-    if (shouldSkipAnalysis()) {
-      return;
-    }
-    currentAutoAnalysis = new Analysis(project, files, action, callback);
-    TaskRunnerKt.startBackgroundableModalTask(project, ANALYSIS_TASK_TITLE, currentAutoAnalysis::run);
+    var analysis = new Analysis(project, files, action, callback);
+    TaskRunnerKt.startBackgroundableModalTask(project, ANALYSIS_TASK_TITLE, analysis::run);
+    return analysis;
   }
 
   private boolean shouldSkipAnalysis() {

--- a/src/main/java/org/sonarlint/intellij/analysis/FindingStreamer.java
+++ b/src/main/java/org/sonarlint/intellij/analysis/FindingStreamer.java
@@ -92,6 +92,7 @@ public class FindingStreamer implements AutoCloseable {
     }
 
     public void stop() {
+      endRunnable.run();
       cancelRunning();
       executorService.shutdownNow();
     }

--- a/src/main/java/org/sonarlint/intellij/core/ServerIssueUpdater.java
+++ b/src/main/java/org/sonarlint/intellij/core/ServerIssueUpdater.java
@@ -137,8 +137,8 @@ public final class ServerIssueUpdater implements Disposable {
 
       // submit tasks
       var updateTasks = fetchAndMatchServerIssues(filesPerModule, connection, engine, downloadAll);
-      Future<?> waitForTasksTask = executorService.submit(() -> waitForTasks(myProject, updateTasks, "ServerIssueUpdater"));
-      waitForTask(myProject, waitForTasksTask, "Wait", Duration.ofSeconds(60));
+      Future<?> waitForTasksTask = executorService.submit(() -> waitForTasks(myProject, indicator, updateTasks, "ServerIssueUpdater"));
+      waitForTask(myProject, indicator, waitForTasksTask, "Wait", Duration.ofSeconds(60));
     } catch (InvalidBindingException e) {
       // ignore, do nothing
     }

--- a/src/main/java/org/sonarlint/intellij/core/ServerIssueUpdater.java
+++ b/src/main/java/org/sonarlint/intellij/core/ServerIssueUpdater.java
@@ -110,7 +110,7 @@ public final class ServerIssueUpdater implements Disposable {
     }
   }
 
-  public void fetchAndMatchServerIssues(Map<Module, Collection<VirtualFile>> filesPerModule, ProgressIndicator indicator, boolean waitForCompletion) {
+  public void fetchAndMatchServerIssues(Map<Module, Collection<VirtualFile>> filesPerModule, ProgressIndicator indicator) {
     var projectSettings = getSettingsFor(myProject);
     if (!projectSettings.isBound()) {
       // not in connected mode
@@ -130,9 +130,7 @@ public final class ServerIssueUpdater implements Disposable {
       } else {
         msg = "Fetching server issues in " + numFiles + SonarLintUtils.pluralize(" file", numFiles);
       }
-      if (waitForCompletion) {
-        msg += " (waiting for results)";
-      }
+      msg += " (waiting for results)";
       var console = getService(myProject, SonarLintConsole.class);
       console.debug(msg);
       indicator.setText(msg);
@@ -140,9 +138,7 @@ public final class ServerIssueUpdater implements Disposable {
       // submit tasks
       var updateTasks = fetchAndMatchServerIssues(filesPerModule, connection, engine, downloadAll);
       Future<?> waitForTasksTask = executorService.submit(() -> waitForTasks(myProject, updateTasks, "ServerIssueUpdater"));
-      if (waitForCompletion) {
-        waitForTask(myProject, waitForTasksTask, "Wait", Duration.ofSeconds(60));
-      }
+      waitForTask(myProject, waitForTasksTask, "Wait", Duration.ofSeconds(60));
     } catch (InvalidBindingException e) {
       // ignore, do nothing
     }

--- a/src/main/java/org/sonarlint/intellij/finding/hotspot/ServerSecurityHotspotUpdater.java
+++ b/src/main/java/org/sonarlint/intellij/finding/hotspot/ServerSecurityHotspotUpdater.java
@@ -112,8 +112,7 @@ public final class ServerSecurityHotspotUpdater implements Disposable {
     }
   }
 
-  public void fetchAndMatchServerSecurityHotspots(Map<Module, Collection<VirtualFile>> filesPerModule, ProgressIndicator indicator,
-    boolean waitForCompletion) {
+  public void fetchAndMatchServerSecurityHotspots(Map<Module, Collection<VirtualFile>> filesPerModule, ProgressIndicator indicator) {
     var projectSettings = getSettingsFor(myProject);
     if (!projectSettings.isBound()) {
       // not in connected mode
@@ -139,9 +138,7 @@ public final class ServerSecurityHotspotUpdater implements Disposable {
     } else {
       msg = "Fetching server hotspots in " + numFiles + SonarLintUtils.pluralize(" file", numFiles);
     }
-    if (waitForCompletion) {
-      msg += " (waiting for results)";
-    }
+    msg += " (waiting for results)";
     var console = getService(myProject, SonarLintConsole.class);
     console.debug(msg);
     indicator.setText(msg);
@@ -149,9 +146,7 @@ public final class ServerSecurityHotspotUpdater implements Disposable {
     // submit tasks
     var updateTasks = fetchAndMatchServerSecurityHotspots(filesPerModule, connection, engine, downloadAll);
     Future<?> waitForTasksTask = executorService.submit(() -> waitForTasks(myProject, updateTasks, "ServerHotspotUpdater"));
-    if (waitForCompletion) {
-      waitForTask(myProject, waitForTasksTask, "Wait", Duration.ofSeconds(60));
-    }
+    waitForTask(myProject, waitForTasksTask, "Wait", Duration.ofSeconds(60));
   }
 
   private List<Future<?>> fetchAndMatchServerSecurityHotspots(Map<Module, Collection<VirtualFile>> filesPerModule,

--- a/src/main/java/org/sonarlint/intellij/finding/hotspot/ServerSecurityHotspotUpdater.java
+++ b/src/main/java/org/sonarlint/intellij/finding/hotspot/ServerSecurityHotspotUpdater.java
@@ -145,8 +145,8 @@ public final class ServerSecurityHotspotUpdater implements Disposable {
 
     // submit tasks
     var updateTasks = fetchAndMatchServerSecurityHotspots(filesPerModule, connection, engine, downloadAll);
-    Future<?> waitForTasksTask = executorService.submit(() -> waitForTasks(myProject, updateTasks, "ServerHotspotUpdater"));
-    waitForTask(myProject, waitForTasksTask, "Wait", Duration.ofSeconds(60));
+    Future<?> waitForTasksTask = executorService.submit(() -> waitForTasks(myProject, indicator, updateTasks, "ServerHotspotUpdater"));
+    waitForTask(myProject, indicator, waitForTasksTask, "Wait", Duration.ofSeconds(60));
   }
 
   private List<Future<?>> fetchAndMatchServerSecurityHotspots(Map<Module, Collection<VirtualFile>> filesPerModule,

--- a/src/main/java/org/sonarlint/intellij/tasks/FutureAwaitingTask.kt
+++ b/src/main/java/org/sonarlint/intellij/tasks/FutureAwaitingTask.kt
@@ -22,7 +22,11 @@ package org.sonarlint.intellij.tasks
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
-import java.util.concurrent.*
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 open class FutureAwaitingTask<T>(
     project: Project,

--- a/src/main/java/org/sonarlint/intellij/util/FutureUtils.java
+++ b/src/main/java/org/sonarlint/intellij/util/FutureUtils.java
@@ -19,18 +19,21 @@
  */
 package org.sonarlint.intellij.util;
 
+import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.sonarlint.intellij.common.ui.SonarLintConsole;
 
 public class FutureUtils {
-  public static void waitForTask(Project project, Future<?> task, String taskName, Duration timeoutDuration) {
+  public static void waitForTask(Project project, ProgressIndicator indicator, Future<?> task, String taskName, Duration timeoutDuration) {
     try {
-      task.get(timeoutDuration.getSeconds(), TimeUnit.SECONDS);
+      waitForFuture(indicator, task, timeoutDuration);
     } catch (TimeoutException ex) {
       task.cancel(true);
       SonarLintConsole.get(project).error(taskName + " task expired", ex);
@@ -41,10 +44,32 @@ public class FutureUtils {
     }
   }
 
-  public static void waitForTasks(Project project, List<Future<?>> updateTasks, String taskName) {
+  public static void waitForTasks(Project project, ProgressIndicator indicator, List<Future<?>> updateTasks, String taskName) {
     for (var f : updateTasks) {
-      waitForTask(project, f, taskName, Duration.ofSeconds(20));
+      waitForTask(project, indicator, f, taskName, Duration.ofSeconds(20));
     }
+  }
+
+  private static void waitForFuture(ProgressIndicator indicator, Future<?> future, Duration durationTimeout) throws InterruptedException, ExecutionException, TimeoutException {
+    long counter = 0;
+    while (counter < durationTimeout.toMillis()) {
+      counter += 100;
+      if (indicator.isCanceled()) {
+        future.cancel(true);
+        return;
+      }
+      try {
+        future.get(100, TimeUnit.MILLISECONDS);
+        return;
+      } catch (TimeoutException ignored) {
+        continue;
+      } catch (InterruptedException | CancellationException e) {
+        throw new InterruptedException("Interrupted");
+      } catch (ExecutionException e) {
+        throw e;
+      }
+    }
+    throw new TimeoutException();
   }
 
   private FutureUtils() {

--- a/src/test/java/org/sonarlint/intellij/analysis/AnalysisTests.java
+++ b/src/test/java/org/sonarlint/intellij/analysis/AnalysisTests.java
@@ -91,7 +91,7 @@ class AnalysisTests extends AbstractSonarLintLightTests {
     replaceProjectService(ServerIssueUpdater.class, mock(ServerIssueUpdater.class));
     replaceProjectService(FindingsCache.class, findingsCacheMock);
 
-    task = new Analysis(getProject(), filesToAnalyze, TriggerType.ACTION, false, mock(AnalysisCallback.class));
+    task = new Analysis(getProject(), filesToAnalyze, TriggerType.ACTION, mock(AnalysisCallback.class));
 
     // IntelliJ light test fixtures appear to reuse the same project container, so we need to ensure that status is stopped.
     AnalysisStatus.get(getProject()).stopRun();

--- a/src/test/java/org/sonarlint/intellij/core/ServerIssueUpdaterTests.java
+++ b/src/test/java/org/sonarlint/intellij/core/ServerIssueUpdaterTests.java
@@ -89,7 +89,7 @@ class ServerIssueUpdaterTests extends AbstractSonarLintLightTests {
     var file = myFixture.copyFileToProject(FOO_PHP, FOO_PHP);
     getProjectSettings().setBindingEnabled(false);
 
-    underTest.fetchAndMatchServerIssues(Map.of(getModule(), List.of(file)), new EmptyProgressIndicator(), false);
+    underTest.fetchAndMatchServerIssues(Map.of(getModule(), List.of(file)), new EmptyProgressIndicator());
     verifyNoInteractions(findingsCache);
   }
 
@@ -106,7 +106,7 @@ class ServerIssueUpdaterTests extends AbstractSonarLintLightTests {
     // run
     getProjectSettings().setBindingEnabled(true);
 
-    underTest.fetchAndMatchServerIssues(Map.of(getModule(), List.of(file)), new EmptyProgressIndicator(), false);
+    underTest.fetchAndMatchServerIssues(Map.of(getModule(), List.of(file)), new EmptyProgressIndicator());
 
     verify(mockedConsole, never()).error(anyString());
     verify(mockedConsole, never()).error(anyString(), any(Throwable.class));
@@ -129,7 +129,7 @@ class ServerIssueUpdaterTests extends AbstractSonarLintLightTests {
     // run
     getProjectSettings().setBindingEnabled(true);
 
-    underTest.fetchAndMatchServerIssues(Map.of(getModule(), files), new EmptyProgressIndicator(), false);
+    underTest.fetchAndMatchServerIssues(Map.of(getModule(), files), new EmptyProgressIndicator());
 
     verify(engine, timeout(500)).downloadAllServerIssues(any(), any(), eq(PROJECT_KEY), anyString(), isNull());
     verify(mockedConsole, never()).error(anyString());


### PR DESCRIPTION
Remove parameter `waitForServerFindings` and put true by default. As a result, we will always wait for the server matching to be finished before ending the analysis.

The drawback is that the analysis might stay blocked for up to 60 seconds (timeout duration for the tasks) when waiting for the server findings.

As a result, I improved the analysis cancellation process (currently, we check if the status is `CANCELLING` only during the analysis of the modules, and before waiting for the server findings, so pressing the cancel button during the fetching had no effect).