### PR TITLE
SLI-952: Update CFamily analyzer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -216,7 +216,7 @@ dependencies {
     "sqplugins"("org.sonarsource.slang:sonar-go-plugin:1.12.0.4259")
     "sqplugins"("org.sonarsource.iac:sonar-iac-plugin:1.16.0.3845")
     if (artifactoryUsername.isNotEmpty() && artifactoryPassword.isNotEmpty()) {
-        "sqplugins"("com.sonarsource.cpp:sonar-cfamily-plugin:6.44.0.61773")
+        "sqplugins"("com.sonarsource.cpp:sonar-cfamily-plugin:6.45.0.62016")
     }
     // workaround for light tests in 2020.3, might remove later
     testRuntimeOnly("org.jetbrains.kotlin:kotlin-reflect")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -64,7 +64,7 @@
 
     <change-notes><![CDATA[
       <ul>
-        <li>8.3 - Allow changing status of Security Hotspots. Support analysis of Go not only in GoLand but also when using the Go plugin in IntelliJ IDEA Ultimate. 17 new rules for JavaScript. 6 new rules for PHP. 10 new rules, 1 new quick fix for Python. 9 new rules for Kotlin.</li>
+        <li>8.3 - Allow changing status of Security Hotspots. Support analysis of Go not only in GoLand but also when using the Go plugin in IntelliJ IDEA Ultimate. 17 new rules for JavaScript. 6 new rules for PHP. 10 new rules, 1 new quick fix for Python. 9 new rules for Kotlin. Bug fixes, fewer FPs and improvements for many languages.</li>
         <li>8.2 - Support syntax highlighting and diff view for code examples. Add support for CloudFormation, Docker, Kubernetes and Terraform. 3 new rules for Java. 8 new rules for JavaScript. 2 new rules for C# in Rider. 9 new rules for Kotlin. 11 new rules, 3 new quick fixes for Python. Bug fixes, fewer FPs and improvements for many languages.</li>
         <li>8.1 - Support analysis of Go in GoLand. Support for tiarmclang compiler, Kotlin 1.8 and IPython syntax. 6 new rules for C# in Rider. Bug fixes, fewer FPs and improvements for many languages.</li>
         <li>8.0 - Raise minimal supported version to 2021.3. Report Security Hotspots locally when connected to SonarQube 9.7+. Support of JavaScript analysis in HTML files. Support for clang-cl and Microchip compilers. New quick fixes for 11 Java rules. New quick fix for a C++ rule. New quick fixes for 17 Python rules. 6 new rules for C# in Rider. Bug fixes, fewer FPs and improvements for many languages.</li>


### PR DESCRIPTION
Release notes edited as the update only contained improvements.