### PR TITLE
BUILD-3527 Do not override build version on Cirrus `validate_task`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -102,7 +102,6 @@ validate_task:
   build_script: |
     source cirrus-env QA
     source .cirrus/use-gradle-wrapper.sh
-    source .cirrus/set_gradle_build_version
     PULL_REQUEST_SHA=$GIT_SHA1 regular_gradle_build_deploy_analyze check -x :its:check -x artifactoryPublish :runPluginVerifier sonarqube jacocoTestReport
   <<: *CLEANUP_GRADLE_CACHE_SCRIPT
   on_failure:


### PR DESCRIPTION
This script is doing the following:

     Replacing version 9.0-SNAPSHOT with 9.0.0.$build_version

Which should not happen in this step.