### PR TITLE
SLI-1044 Check if rule panel is disposed when parsing description

### DIFF
--- a/src/main/java/org/sonarlint/intellij/ui/ruledescription/RuleParsingUtils.kt
+++ b/src/main/java/org/sonarlint/intellij/ui/ruledescription/RuleParsingUtils.kt
@@ -87,16 +87,22 @@ class RuleParsingUtils {
                 section.mergeOrAdd(HtmlFragment(remainingRuleDescription))
             }
 
+            transformAndAddSections(section, project, parent, fileType, mainPanel)
+
+            return createScrollPane(mainPanel)
+        }
+
+        private fun transformAndAddSections(section: Section, project: Project, parent: Disposable, fileType: FileType, mainPanel: JBPanel<*>) {
             section.fragments.map {
                 when (it) {
                     is HtmlFragment -> RuleHtmlViewer(false).apply { updateHtml(it.html) }
                     is CodeExampleFragment -> RuleCodeSnippet(project, fileType, it).apply {
-                        Disposer.register(parent, this)
+                        if (!Disposer.isDisposed(parent)) {
+                            Disposer.register(parent, this)
+                        }
                     }
                 }
             }.forEach { mainPanel.add(it) }
-
-            return createScrollPane(mainPanel)
         }
 
         private fun isWithinTable(previousHtml: String): Boolean {


### PR DESCRIPTION
Reproducible by setting a thread sleep inside the new thread starting when loading the rules.

This happens when we save the rule panel, on `apply()` we do a `reset()` that load a bunch of stuff, including rules in a background thread.

With some unfortunate timing, or by simulating a thread sleep, we see that the panel is disposed but the background thread keeps going and tries to register the parent (which is now disposed).