### PR TITLE
Increase memory during Promote task to avoid OOM errors

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -253,7 +253,7 @@ promote_task:
   eks_container:
     <<: *CONTAINER_DEFINITION
     cpu: 3
-    memory: 2G
+    memory: 4G
   env:
     GCF_ACCESS_TOKEN: VAULT[development/kv/data/promote data.token]
     PROMOTE_URL: VAULT[development/kv/data/promote data.url]


### PR DESCRIPTION
```
CI agent stopped responding!
Container errored with 'Container main terminated with OOMKilled'
```
https://cirrus-ci.com/task/4635411696320512