### PR TITLE
Dependencies should be downloaded from Repox in priority

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,17 +61,17 @@ allprojects {
     }
 
     repositories {
-        mavenCentral {
-            content {
-                excludeGroupByRegex("com\\.sonarsource.*")
-            }
-        }
         maven("https://repox.jfrog.io/repox/sonarsource") {
             if (artifactoryUsername.isNotEmpty() && artifactoryPassword.isNotEmpty()) {
                 credentials {
                     username = artifactoryUsername
                     password = artifactoryPassword
                 }
+            }
+        }
+        mavenCentral {
+            content {
+                excludeGroupByRegex("com\\.sonarsource.*")
             }
         }
     }


### PR DESCRIPTION
Looking at Cirrus logs, we download every dependency from maven central (Sonar scanners, etc.). We should probably do it from Repox if the dependencies are available there.