### PR TITLE
SLI-1286 Short UI freeze when listing project files

### DIFF
--- a/src/test/java/org/sonarlint/intellij/SonarLintIntelliJClientTests.kt
+++ b/src/test/java/org/sonarlint/intellij/SonarLintIntelliJClientTests.kt
@@ -61,7 +61,7 @@ class SonarLintIntelliJClientTests : AbstractSonarLintLightTests() {
         val result = client.listFiles(projectBackendId)
 
         assertThat(result).extracting(ClientFileDto::getIdeRelativePath, ClientFileDto::getContent)
-            .containsOnly(tuple(Paths.get("file.properties"), "content=hey\n"))
+            .containsOnly(tuple(Paths.get("file.properties"), null))
     }
 
     @Test
@@ -72,7 +72,28 @@ class SonarLintIntelliJClientTests : AbstractSonarLintLightTests() {
         val result = client.listFiles(projectBackendId)
 
         assertThat(result).extracting(ClientFileDto::getIdeRelativePath, ClientFileDto::getContent)
-            .containsOnly(tuple(Paths.get("file.properties"), "precontent=hey\n"))
+            .containsOnly(tuple(Paths.get("file.properties"), null))
+    }
+
+    @Test
+    fun it_should_find_files_with_content_if_specific_property_file() {
+        myFixture.configureByFile("sonar-project.properties")
+
+        val result = client.listFiles(projectBackendId)
+
+        assertThat(result).extracting(ClientFileDto::getIdeRelativePath, ClientFileDto::getContent)
+            .containsOnly(tuple(Paths.get("sonar-project.properties"), "content=hey\n"))
+    }
+
+    @Test
+    fun it_should_find_files_with_content_if_specific_property_file_and_has_one_modified_in_editor() {
+        myFixture.configureByFile("sonar-project.properties")
+        myFixture.type("pre")
+
+        val result = client.listFiles(projectBackendId)
+
+        assertThat(result).extracting(ClientFileDto::getIdeRelativePath, ClientFileDto::getContent)
+            .containsOnly(tuple(Paths.get("sonar-project.properties"), "precontent=hey\n"))
     }
 
     @Test

--- a/src/test/testData/SonarLintIntelliJClientTests/sonar-project.properties
+++ b/src/test/testData/SonarLintIntelliJClientTests/sonar-project.properties
@@ -1,0 +1,1 @@
+content=hey


### PR DESCRIPTION
- `FileIndex.iterateContent()` -> Iteration methods ("iterateX") may be called outside of a read action (since iteration can take a long time), but they should be prepared to project model being changed in the middle of the iteration.
- `VirtualFile.children()` -> Gets the child files. The returned files are guaranteed to be valid, if the method is called in a read action.