### PR TITLE
SLI-1291 Allow external contributors to build SLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For the complete list of tasks, see:
 
     ./gradlew tasks
 
-For external contributors, building the project should be guaranteed to work from any specific tag. During the development phase, some
+For external contributors, the project should be guaranteed to build from any specific tag. During the development phase, some
 unreleased dependencies not accessible to the public could be used, preventing you from building the project.
 
 How to run ITs

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ For the complete list of tasks, see:
 
     ./gradlew tasks
 
+For external contributors, building the project should be guaranteed to work from any specific tag. During the development phase, some
+unreleased dependencies not accessible to the public could be used, preventing you from building the project.
+
 How to run ITs
 ------------
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,12 @@ allprojects {
                 }
             }
         }
+        mavenCentral {
+            content {
+                // avoid dependency confusion
+                excludeGroupByRegex("com\\.sonarsource.*")
+            }
+        }
     }
 
     java {
@@ -217,11 +223,11 @@ dependencies {
     "sqplugins"(libs.bundles.sonar.analyzers)
     if (artifactoryUsername.isNotEmpty() && artifactoryPassword.isNotEmpty()) {
         "sqplugins"(libs.sonar.cfamily)
+        "omnisharp"("org.sonarsource.sonarlint.omnisharp:omnisharp-roslyn:$omnisharpVersion:mono@zip")
+        "omnisharp"("org.sonarsource.sonarlint.omnisharp:omnisharp-roslyn:$omnisharpVersion:net472@zip")
+        "omnisharp"("org.sonarsource.sonarlint.omnisharp:omnisharp-roslyn:$omnisharpVersion:net6@zip")
     }
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    "omnisharp"("org.sonarsource.sonarlint.omnisharp:omnisharp-roslyn:$omnisharpVersion:mono@zip")
-    "omnisharp"("org.sonarsource.sonarlint.omnisharp:omnisharp-roslyn:$omnisharpVersion:net472@zip")
-    "omnisharp"("org.sonarsource.sonarlint.omnisharp:omnisharp-roslyn:$omnisharpVersion:net6@zip")
 }
 
 tasks {


### PR DESCRIPTION
It seems that our omnisharp-roslyn is not pushed on maven central, so I avoid the download of this dependency if user has not defined credentials to Repox