### PR TITLE
Checking if file is test source should be in a read action

### DIFF
--- a/src/main/java/org/sonarlint/intellij/SonarLintIntelliJClient.kt
+++ b/src/main/java/org/sonarlint/intellij/SonarLintIntelliJClient.kt
@@ -555,7 +555,15 @@ object SonarLintIntelliJClient : SonarLintRpcClientDelegate {
         if (file.name == SONAR_SCANNER_CONFIG_FILENAME || file.name == AUTOSCAN_CONFIG_FILENAME) {
             fileContent = computeReadActionSafely(project) { getFileContent(file) }
         }
-        return ClientFileDto(uri, Paths.get(relativePath), configScopeId, TestSourcesFilter.isTestSources(file, project), file.charset.name(), Paths.get(file.path), fileContent)
+        return ClientFileDto(
+            uri,
+            Paths.get(relativePath),
+            configScopeId,
+            computeReadActionSafely(project) { TestSourcesFilter.isTestSources(file, project) },
+            file.charset.name(),
+            Paths.get(file.path),
+            fileContent
+        )
     }
 
     private fun listFilesInContentRoots(


### PR DESCRIPTION
```
com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments: Read access is allowed from inside read-action only (see Application.runReadAction()); see https://jb.gg/ij-platform-threading for details
Current thread: Thread[SonarLint Client RPC request executor,4,main] 1004599971 (EventQueue.isDispatchThread()=false)
SystemEventQueueThread: Thread[AWT-EventQueue-0,6,main] 1718815322
	at com.intellij.util.concurrency.ThreadingAssertions.createThreadAccessException(ThreadingAssertions.java:156)
	at com.intellij.util.concurrency.ThreadingAssertions.softAssertReadAccess(ThreadingAssertions.java:107)
	at com.intellij.openapi.application.impl.ApplicationImpl.assertReadAccessAllowed(ApplicationImpl.java:912)
	at com.intellij.psi.impl.source.PsiFileImpl.assertReadAccessAllowed(PsiFileImpl.java:182)
	at com.intellij.psi.impl.source.PsiFileImpl.getStubTree(PsiFileImpl.java:617)
	at com.intellij.psi.impl.source.PsiFileImpl.getGreenStubTree(PsiFileImpl.java:952)
	at com.intellij.psi.impl.source.PsiFileImpl.getGreenStub(PsiFileImpl.java:607)
	at com.intellij.lang.javascript.psi.impl.JSFileBaseImpl.getGreenJSFileStub(JSFileBaseImpl.java:65)
	at com.intellij.lang.javascript.psi.impl.JSFileBaseImpl.getCachedData(JSFileBaseImpl.java:52)
	at com.intellij.lang.javascript.psi.impl.JSFileBaseImpl.getTestFileType(JSFileBaseImpl.java:124)
	at com.intellij.lang.javascript.psi.impl.JSFileBaseImpl.isTestFile(JSFileBaseImpl.java:119)
	at com.intellij.javascript.testFramework.JsTestFileIndexingHandler.isTestFile(JsTestFileIndexingHandler.java:92)
	at com.intellij.javascript.testing.JsTestSourcesFilter.isTestSource(JsTestSourcesFilter.java:12)
	at com.intellij.openapi.roots.TestSourcesFilter.isTestSources(TestSourcesFilter.java:31)
	at org.sonarlint.intellij.SonarLintIntelliJClient.toClientFileDto(SonarLintIntelliJClient.kt:558)
	at org.sonarlint.intellij.SonarLintIntelliJClient.listModuleFiles(SonarLintIntelliJClient.kt:535)
	at org.sonarlint.intellij.SonarLintIntelliJClient.listFiles(SonarLintIntelliJClient.kt:527)
	at org.sonarsource.sonarlint.core.rpc.client.SonarLintRpcClientImpl.lambda$listFiles$26(SonarLintRpcClientImpl.java:272)
	at org.sonarsource.sonarlint.core.rpc.client.SonarLintRpcClientImpl.lambda$requestAsync$1(SonarLintRpcClientImpl.java:103)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```