### PR TITLE
NO-JIRA: Change Slack channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
       contents: write
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
     with:
-      slackChannel: team-sonarlint-intelliclipse-notifs
+      slackChannel: squad-ide-intellij-family-bots


### PR DESCRIPTION
Split the old notification channel for the IntelliClipse squad