### PR TITLE
Enable filtering issues by severity in Current File and Report tab

### DIFF
--- a/src/main/java/org/sonarlint/intellij/actions/FilterIssueSeverityActionGroup.java
+++ b/src/main/java/org/sonarlint/intellij/actions/FilterIssueSeverityActionGroup.java
@@ -1,0 +1,67 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) 2015-2024 SonarSource
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.actions;
+
+import com.intellij.openapi.actionSystem.ActionGroup;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import javax.swing.Icon;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.sonarlint.intellij.actions.filters.FilterIssueSeverityAction;
+import org.sonarlint.intellij.actions.filters.FilterIssueSeveritySettings;
+import org.sonarlint.intellij.actions.filters.IssueSeverityFilters;
+
+public class FilterIssueSeverityActionGroup extends ActionGroup {
+
+  private final FilterIssueSeverityAction[] myChildren;
+  private final FilterIssueSeveritySettings settings;
+
+  public FilterIssueSeverityActionGroup(String title, String description, @Nullable Icon icon) {
+    super(title, description, icon);
+    setPopup(true);
+
+    settings = new FilterIssueSeveritySettings();
+
+    myChildren = new FilterIssueSeverityAction[] {
+      new FilterIssueSeverityAction(IssueSeverityFilters.SHOW_ALL, settings),
+      new FilterIssueSeverityAction(IssueSeverityFilters.INFO, settings),
+      new FilterIssueSeverityAction(IssueSeverityFilters.MINOR, settings),
+      new FilterIssueSeverityAction(IssueSeverityFilters.MAJOR, settings),
+      new FilterIssueSeverityAction(IssueSeverityFilters.CRITICAL, settings),
+      new FilterIssueSeverityAction(IssueSeverityFilters.BLOCKER, settings)
+    };
+  }
+
+  public void resetToDefaultSettings(AnActionEvent e) {
+    for (var child : myChildren) {
+      if (child.getFilter() == IssueSeverityFilters.DEFAULT_FILTER) {
+        child.setSelected(e, true);
+      }
+    }
+  }
+
+  @NotNull
+  @Override
+  public AnAction[] getChildren(@Nullable AnActionEvent e) {
+    return myChildren;
+  }
+
+}

--- a/src/main/java/org/sonarlint/intellij/actions/SonarLintToolWindow.java
+++ b/src/main/java/org/sonarlint/intellij/actions/SonarLintToolWindow.java
@@ -40,6 +40,7 @@ import java.util.function.Consumer;
 import javax.swing.SwingUtilities;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.sonarlint.intellij.actions.filters.IssueSeverityFilters;
 import org.sonarlint.intellij.actions.filters.SecurityHotspotFilters;
 import org.sonarlint.intellij.analysis.AnalysisResult;
 import org.sonarlint.intellij.editor.CodeAnalyzerRestarter;
@@ -146,6 +147,14 @@ public final class SonarLintToolWindow implements ContentManagerListener, Projec
 
   public void filterCurrentFileTab(boolean isResolved) {
     this.<CurrentFilePanel>updateTab(SonarLintToolWindowFactory.CURRENT_FILE_TAB_TITLE, panel -> panel.allowResolvedIssues(isResolved));
+  }
+
+  public void filterCurrentFileTab(IssueSeverityFilters filter) {
+    this.<CurrentFilePanel>updateTab(SonarLintToolWindowFactory.CURRENT_FILE_TAB_TITLE, panel -> panel.filterByIssueSeverity(filter));
+  }
+
+  public void filterReportTab(IssueSeverityFilters filter) {
+    this.<ReportPanel>updateTab(SonarLintToolWindowFactory.REPORT_TAB_TITLE, panel -> panel.filterByIssueSeverity(filter));
   }
 
   public void filterTaintVulnerabilityTab(boolean isResolved) {

--- a/src/main/java/org/sonarlint/intellij/actions/filters/FilterIssueSeverityAction.java
+++ b/src/main/java/org/sonarlint/intellij/actions/filters/FilterIssueSeverityAction.java
@@ -1,0 +1,72 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) 2015-2024 SonarSource
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.actions.filters;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+import org.sonarlint.intellij.actions.AbstractSonarToggleAction;
+import org.sonarlint.intellij.actions.SonarLintToolWindow;
+
+import static org.sonarlint.intellij.common.util.SonarLintUtils.getService;
+
+public class FilterIssueSeverityAction extends AbstractSonarToggleAction {
+
+  private final IssueSeverityFilters filter;
+  private final FilterIssueSeveritySettings settings;
+
+  public FilterIssueSeverityAction(IssueSeverityFilters filter, FilterIssueSeveritySettings settings) {
+    this.filter = filter;
+    this.settings = settings;
+  }
+
+  public IssueSeverityFilters getFilter() {
+    return filter;
+  }
+
+  @Override
+  public void update(@NotNull AnActionEvent e) {
+    var project = e.getProject();
+    if (project == null) {
+      return;
+    }
+    e.getPresentation().setText(filter.getTitle(project));
+    super.update(e);
+  }
+
+  @Override
+  public boolean isSelected(@NotNull AnActionEvent e) {
+    return settings.getCurrentlySelectedFilter() == filter;
+  }
+
+  @Override
+  public void setSelected(@NotNull AnActionEvent e, boolean enabled) {
+    var project = e.getProject();
+    if (project == null) {
+      return;
+    }
+
+    if (enabled && settings.getCurrentlySelectedFilter() != filter) {
+      getService(project, SonarLintToolWindow.class).filterCurrentFileTab(filter);
+      getService(project, SonarLintToolWindow.class).filterReportTab(filter);
+      settings.setCurrentlySelectedFilter(filter);
+    }
+  }
+
+}

--- a/src/main/java/org/sonarlint/intellij/actions/filters/FilterIssueSeveritySettings.java
+++ b/src/main/java/org/sonarlint/intellij/actions/filters/FilterIssueSeveritySettings.java
@@ -1,0 +1,38 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) 2015-2024 SonarSource
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.actions.filters;
+
+public class FilterIssueSeveritySettings {
+
+  private IssueSeverityFilters currentlySelectedFilter;
+
+  public FilterIssueSeveritySettings() {
+    this.currentlySelectedFilter = IssueSeverityFilters.DEFAULT_FILTER;
+  }
+
+  public IssueSeverityFilters getCurrentlySelectedFilter() {
+    return currentlySelectedFilter;
+  }
+
+  public void setCurrentlySelectedFilter(IssueSeverityFilters filter) {
+    currentlySelectedFilter = filter;
+  }
+
+}

--- a/src/main/java/org/sonarlint/intellij/actions/filters/IssueSeverityFilters.java
+++ b/src/main/java/org/sonarlint/intellij/actions/filters/IssueSeverityFilters.java
@@ -1,0 +1,56 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) 2015-2024 SonarSource
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.actions.filters;
+
+import com.intellij.openapi.project.Project;
+import java.util.function.Function;
+
+import org.sonarsource.sonarlint.core.rpc.protocol.common.IssueSeverity;
+
+public enum IssueSeverityFilters {
+
+  SHOW_ALL(p -> "Show All"),
+  INFO(p -> "Info"),
+  MINOR(p -> "Minor"),
+  MAJOR(p -> "Major"),
+  CRITICAL(p -> "Critical"),
+  BLOCKER(p -> "Blocker");
+
+  public static final IssueSeverityFilters DEFAULT_FILTER = SHOW_ALL;
+  private final Function<Project, String> titleSupplier;
+
+  IssueSeverityFilters(Function<Project, String> titleSupplier) {
+    this.titleSupplier = titleSupplier;
+  }
+
+  public String getTitle(Project project) {
+    return titleSupplier.apply(project);
+  }
+
+  public boolean shouldIncludeIssue(IssueSeverity severity) {
+    return switch (severity) {
+        case INFO ->  this.compareTo(INFO) <= 0;
+        case MINOR -> this.compareTo(MINOR) <= 0;
+        case MAJOR -> this.compareTo(MAJOR) <= 0;
+        case CRITICAL -> this.compareTo(CRITICAL) <= 0;
+        case BLOCKER -> this.compareTo(BLOCKER) <= 0;
+    };
+  }
+}

--- a/src/main/java/org/sonarlint/intellij/util/SonarLintActions.java
+++ b/src/main/java/org/sonarlint/intellij/util/SonarLintActions.java
@@ -29,6 +29,7 @@ import com.intellij.serviceContainer.NonInjectable;
 import org.sonarlint.intellij.SonarLintIcons;
 import org.sonarlint.intellij.actions.ClearCurrentFileIssuesAction;
 import org.sonarlint.intellij.actions.ClearReportAction;
+import org.sonarlint.intellij.actions.FilterIssueSeverityActionGroup;
 import org.sonarlint.intellij.actions.FilterSecurityHotspotActionGroup;
 import org.sonarlint.intellij.actions.RestartBackendAction;
 import org.sonarlint.intellij.actions.SonarAnalyzeAllFilesAction;
@@ -56,6 +57,7 @@ public final class SonarLintActions {
   private final AnAction configureAction;
   private final AnAction analyzeChangedFilesAction;
   private final AnAction analyzeAllFilesAction;
+  private final FilterIssueSeverityActionGroup filterIssueSeverityAction;
   private final FilterSecurityHotspotActionGroup filterAction;
   private final IncludeResolvedFindingsAction<LiveSecurityHotspot> includeResolvedHotspotsAction;
   private final IncludeResolvedFindingsAction<LiveIssue> includeResolvedIssuesAction;
@@ -94,6 +96,9 @@ public final class SonarLintActions {
     analyzeChangedFilesAction = new SonarAnalyzeChangedFilesAction("Analyze VCS Changed Files",
       "Run a SonarLint analysis on VCS changed files",
       SonarLintIcons.SCM);
+    filterIssueSeverityAction = new FilterIssueSeverityActionGroup("Filter Severity",
+       "Filter Severity",
+       AllIcons.General.Filter);
     filterAction = new FilterSecurityHotspotActionGroup("Filter Security Hotspots",
       "Filter Security Hotspots",
       AllIcons.General.Filter);
@@ -145,6 +150,10 @@ public final class SonarLintActions {
 
   public AnAction analyzeAllFiles() {
     return analyzeAllFilesAction;
+  }
+
+  public FilterIssueSeverityActionGroup filterIssueSeverity() {
+    return filterIssueSeverityAction;
   }
 
   public FilterSecurityHotspotActionGroup filterSecurityHotspots() {

--- a/src/test/java/org/sonarlint/intellij/actions/FilterIssueSeverityActionGroupTests.java
+++ b/src/test/java/org/sonarlint/intellij/actions/FilterIssueSeverityActionGroupTests.java
@@ -1,0 +1,112 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) 2015-2024 SonarSource
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.sonarlint.intellij.AbstractSonarLintLightTests;
+import org.sonarlint.intellij.actions.filters.FilterIssueSeverityAction;
+import org.sonarlint.intellij.actions.filters.IssueSeverityFilters;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class FilterIssueSeverityActionGroupTests extends AbstractSonarLintLightTests {
+
+  private FilterIssueSeverityActionGroup actionGroup;
+  private SonarLintToolWindow toolWindow;
+
+  @BeforeEach
+  void prepare() {
+    toolWindow = mock(SonarLintToolWindow.class);
+    replaceProjectService(SonarLintToolWindow.class, toolWindow);
+    actionGroup = new FilterIssueSeverityActionGroup("title", "description", null);
+  }
+
+  @ParameterizedTest
+  @EnumSource(IssueSeverityFilters.class)
+  void testSelectingShowAllFilter(IssueSeverityFilters filter) {
+    var event = mock(AnActionEvent.class);
+    when(event.getProject()).thenReturn(getProject());
+
+    FilterIssueSeverityAction action = (FilterIssueSeverityAction) actionGroup.getChildren(event)[0];
+    action.setSelected(event, true);
+
+    // Show All is already selected by default, it shouldn't trigger a new filtering
+    verify(toolWindow, never()).filterCurrentFileTab(filter);
+    verify(toolWindow, never()).filterReportTab(filter);
+  }
+
+  @Test
+  void testSelectingFilter() {
+    var event = mock(AnActionEvent.class);
+    when(event.getProject()).thenReturn(getProject());
+
+    FilterIssueSeverityAction action = (FilterIssueSeverityAction) actionGroup.getChildren(event)[1];
+    action.setSelected(event, true);
+
+    verify(toolWindow, never()).filterCurrentFileTab(IssueSeverityFilters.SHOW_ALL);
+    verify(toolWindow).filterCurrentFileTab(IssueSeverityFilters.INFO);
+    verify(toolWindow, never()).filterCurrentFileTab(IssueSeverityFilters.MINOR);
+    verify(toolWindow, never()).filterCurrentFileTab(IssueSeverityFilters.MAJOR);
+    verify(toolWindow, never()).filterCurrentFileTab(IssueSeverityFilters.CRITICAL);
+    verify(toolWindow, never()).filterCurrentFileTab(IssueSeverityFilters.BLOCKER);
+
+    verify(toolWindow, never()).filterReportTab(IssueSeverityFilters.SHOW_ALL);
+    verify(toolWindow).filterReportTab(IssueSeverityFilters.INFO);
+    verify(toolWindow, never()).filterReportTab(IssueSeverityFilters.MINOR);
+    verify(toolWindow, never()).filterReportTab(IssueSeverityFilters.MAJOR);
+    verify(toolWindow, never()).filterReportTab(IssueSeverityFilters.CRITICAL);
+    verify(toolWindow, never()).filterReportTab(IssueSeverityFilters.BLOCKER);
+  }
+
+  @Test
+  void testIsSelected() {
+    var event = mock(AnActionEvent.class);
+    when(event.getProject()).thenReturn(getProject());
+
+    FilterIssueSeverityAction action = (FilterIssueSeverityAction) actionGroup.getChildren(event)[0];
+    boolean isShowAllSelected = action.isSelected(event);
+    action = (FilterIssueSeverityAction) actionGroup.getChildren(event)[1];
+    boolean isInfoSelected = action.isSelected(event);
+    action = (FilterIssueSeverityAction) actionGroup.getChildren(event)[2];
+    boolean isMinorSelected = action.isSelected(event);
+    action = (FilterIssueSeverityAction) actionGroup.getChildren(event)[3];
+    boolean isMajorSelected = action.isSelected(event);
+    action = (FilterIssueSeverityAction) actionGroup.getChildren(event)[4];
+    boolean isCriticalSelected = action.isSelected(event);
+    action = (FilterIssueSeverityAction) actionGroup.getChildren(event)[5];
+    boolean isBlockerSelected = action.isSelected(event);
+
+    assertThat(isShowAllSelected).isTrue();
+    assertThat(isInfoSelected).isFalse();
+    assertThat(isMinorSelected).isFalse();
+    assertThat(isMajorSelected).isFalse();
+    assertThat(isCriticalSelected).isFalse();
+    assertThat(isBlockerSelected).isFalse();
+  }
+
+}


### PR DESCRIPTION
![grafik](https://github.com/SonarSource/sonarlint-intellij/assets/49242855/3be954fc-02a8-457f-aef4-1d750aaba5b9)

This PR aims to add an option to the `Current File` and `Report` tab that allows to filter the list of issues by their severity. The advantage for the user is to set a threshold that is relevant when analyzing issues found by SonarLint in order to e.g. focus on the more severe issues rather than `info` severity.

This is a feature that was already requested in the past (see https://github.com/sonar-intellij-plugin/sonar-intellij-plugin/issues/95 or https://community.sonarsource.com/t/sonarlint-plugin-intellij-ide-group-by-critical-or-blocker/20062) which is why I think it is still relevant and should be considered for future versions of this plugin.

The implementation is heavily based upon `FilterSecurityHotspotAction` and related classes and provides the same filter for `Current File` and `Report`. It uses a similar approach to display only issues based on the threshold severity filter set by the user.

Since this is my first go at developing an IntelliJ Plugin there might be some oversights on my end that I'd be happy to fix 👍🏼 

Please review our [contribution guidelines](https://github.com/SonarSource/sonarlint-intellij/blob/master/contributing.md).

And please ensure your pull request adheres to the following guidelines: 

- [x] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [x] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [x] Provide a unit test for any code you changed
- [ ] If there is a [JIRA](http://jira.sonarsource.com/browse/SLI) ticket available, please make your commits and pull request start with the ticket ID (SLI-XXXX)
