### PR TITLE
SLI-1670 Migrate deprecated cirrus-module v2 to v3

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
-load("github.com/SonarSource/cirrus-modules@v2", "load_features")
+load("github.com/SonarSource/cirrus-modules@v3", "load_features")
 
 def main(ctx):
   return load_features(ctx)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,7 +47,7 @@ orchestrator_monthly_cache_template: &ORCHESTRATOR_MONTHLY_CACHE_TEMPLATE
     folder: ${ORCHESTRATOR_HOME}
     fingerprint_script: echo ${THIS_MONTH}
 
-eks_container: &CONTAINER_DEFINITION
+container_definition: &CONTAINER_DEFINITION
   image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-g7-latest
   region: eu-central-1
   cluster_name: ${CIRRUS_CLUSTER_NAME}
@@ -64,12 +64,11 @@ eks_builder_container: &BUILDER_CONTAINER_DEFINITION
   builder_instance_type: t3.small
   builder_subnet_id: ${CIRRUS_AWS_SUBNET}
 
-ec2_instance: &WINVM_DEFINITION
+ec2_instance_definition: &WINVM_DEFINITION
   experimental: true
   image: base-windows-jdk17-v20240704125406
   platform: windows
   region: eu-central-1
-  subnet_id: ${CIRRUS_AWS_SUBNET}
   type: c5.4xlarge
 
 setup_gradle_cache_template: &SETUP_GRADLE_CACHE


### PR DESCRIPTION
[SLI-1670](https://sonarsource.atlassian.net/browse/SLI-1670)

1. Update cirrus-module v2 to v3.
2. Do not call the deprecated AWS feature method parameters `subnet_id`.
3. It is recommended to not use `ec2_instance` or `eks_container` root keys.

[SLI-1670]: https://sonarsource.atlassian.net/browse/SLI-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ