### PR TITLE
SLI-1728 Toolwindow icon should not be red when every files are closed

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=10.13-SNAPSHOT
+version=10.13.1-SNAPSHOT
 omnisharpVersion=1.39.10
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=512M -Dfile.encoding=UTF-8
 org.gradle.caching=true

--- a/src/main/java/org/sonarlint/intellij/analysis/OnTheFlyFindingsHolder.kt
+++ b/src/main/java/org/sonarlint/intellij/analysis/OnTheFlyFindingsHolder.kt
@@ -120,6 +120,9 @@ class OnTheFlyFindingsHolder(private val project: Project) : FileEditorManagerLi
         currentSecurityHotspotsPerOpenFile.remove(file)
         // update only Security Hotspots, issues will be updated in reaction to selectionChanged
         updateSecurityHotspots()
+        if (currentIssuesPerOpenFile.isEmpty()) {
+            updateCurrentFileTab()
+        }
     }
 
     private fun updateSecurityHotspots() {

--- a/src/main/java/org/sonarlint/intellij/ui/CurrentFilePanel.java
+++ b/src/main/java/org/sonarlint/intellij/ui/CurrentFilePanel.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import javax.swing.JScrollPane;
@@ -209,13 +210,14 @@ public class CurrentFilePanel extends AbstractIssuesPanel {
   private void updateIcon(@Nullable VirtualFile file, Collection<LiveIssue> issues) {
     var toolWindow = ToolWindowManager.getInstance(project).getToolWindow(SONARLINT_TOOLWINDOW_ID);
     if (toolWindow != null) {
-      doUpdateIcon(file, issues, toolWindow);
+      var isEmpty = issues.stream().filter(i -> !i.isResolved()).collect(Collectors.toSet()).isEmpty();
+      doUpdateIcon(file, isEmpty, toolWindow);
     }
   }
 
-  private static void doUpdateIcon(@Nullable VirtualFile file, Collection<LiveIssue> issues, ToolWindow toolWindow) {
+  private static void doUpdateIcon(@Nullable VirtualFile file, boolean isEmpty, ToolWindow toolWindow) {
     ApplicationManager.getApplication().assertIsDispatchThread();
-    boolean empty = file == null || issues.isEmpty();
+    boolean empty = file == null || isEmpty;
     toolWindow.setIcon(empty ? SonarLintIcons.SONARQUBE_FOR_INTELLIJ_EMPTY_TOOLWINDOW : SonarLintIcons.SONARQUBE_FOR_INTELLIJ_TOOLWINDOW);
   }
 


### PR DESCRIPTION
[SLI-1728](https://sonarsource.atlassian.net/browse/SLI-1728)



[SLI-1728]: https://sonarsource.atlassian.net/browse/SLI-1728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ