### PR TITLE
SLI-1829 URL slug rebranding update

### DIFF
--- a/src/main/java/org/sonarlint/intellij/documentation/SonarLintDocumentation.kt
+++ b/src/main/java/org/sonarlint/intellij/documentation/SonarLintDocumentation.kt
@@ -25,24 +25,24 @@ object SonarLintDocumentation {
         const val BASE_DOCS_URL = "https://docs.sonarsource.com/sonarqube-for-ide/intellij"
         const val CONNECTED_MODE_LINK = "$BASE_DOCS_URL/team-features/connected-mode"
         const val CONNECTED_MODE_SETUP_LINK = "$BASE_DOCS_URL/team-features/connected-mode-setup"
-        const val SECURITY_HOTSPOTS_LINK = "$BASE_DOCS_URL/using-sonarlint/security-hotspots"
-        const val TAINT_VULNERABILITIES_LINK = "$BASE_DOCS_URL/using-sonarlint/taint-vulnerabilities"
+        const val SECURITY_HOTSPOTS_LINK = "$BASE_DOCS_URL/using/security-hotspots"
+        const val TAINT_VULNERABILITIES_LINK = "$BASE_DOCS_URL/using/taint-vulnerabilities"
         const val CLEAN_CODE_LINK = "$BASE_DOCS_URL/concepts/clean-code/introduction"
         const val SUPPORT_POLICY_LINK = "$CONNECTED_MODE_SETUP_LINK/#sonarlint-sonarqube-version-support-policy"
-        const val FOCUS_ON_NEW_CODE_LINK = "$BASE_DOCS_URL/using-sonarlint/investigating-issues/#focusing-on-new-code"
+        const val FOCUS_ON_NEW_CODE_LINK = "$BASE_DOCS_URL/using/investigating-issues/#focusing-on-new-code"
         const val CONNECTED_MODE_BENEFITS_LINK = "$CONNECTED_MODE_LINK/#benefits"
         const val SHARING_CONNECTED_MODE_CONFIGURATION_LINK = "$CONNECTED_MODE_SETUP_LINK/#reuse-the-binding-configuration"
         const val TROUBLESHOOTING_CONNECTED_MODE_SETUP_LINK = "$BASE_DOCS_URL/troubleshooting/#troubleshooting-connected-mode-setup"
-        const val RULE_SECTION_LINK = "$BASE_DOCS_URL/using-sonarlint/rules/#rule-selection"
-        const val FILE_EXCLUSION_LINK = "$BASE_DOCS_URL/using-sonarlint/file-exclusions"
+        const val RULE_SECTION_LINK = "$BASE_DOCS_URL/using/rules/#rule-selection"
+        const val FILE_EXCLUSION_LINK = "$BASE_DOCS_URL/using/file-exclusions"
     }
 
     object SonarQube {
-        const val SMART_NOTIFICATIONS = "https://docs.sonarqube.org/latest/user-guide/sonarlint-connected-mode/"
+        const val SMART_NOTIFICATIONS = "https://docs.sonarsource.com/sonarqube-server/latest/user-guide/sonarlint-connected-mode/"
     }
 
     object SonarCloud {
-        const val SMART_NOTIFICATIONS = "https://docs.sonarsource.com/sonarcloud/improving/sonarlint/#smart-notifications/"
+        const val SMART_NOTIFICATIONS = "https://docs.sonarsource.com/sonarqube-cloud/improving/sonarlint/#smart-notifications/"
     }
 
     object Marketing {


### PR DESCRIPTION
[SLI-1829](https://sonarsource.atlassian.net/browse/SLI-1829)

Part of the rebranding efforts necessitates the update of the URL structure on the Docs website.
This change reflects part of that update.
A redirect has been added to address links from outside the product.

[SLI-1829]: https://sonarsource.atlassian.net/browse/SLI-1829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ