### PR TITLE
SLI-2190 Remove forced UI update

### DIFF
--- a/src/main/java/org/sonarlint/intellij/actions/ChangeDependencyRiskStatusAction.kt
+++ b/src/main/java/org/sonarlint/intellij/actions/ChangeDependencyRiskStatusAction.kt
@@ -94,7 +94,6 @@ class ChangeDependencyRiskStatusAction() : AbstractSonarAction(
         ) {
             getService(BackendService::class.java).changeStatusForDependencyRisk(project, dependencyRisk.id, statusChange, comment)
                 .thenAcceptAsync {
-                    updateUI(project, statusChange, dependencyRisk)
                     SonarLintProjectNotifications.get(project).displaySuccessfulNotification(
                         SUCCESS_CONTENT,
                         NotificationGroupManager.getInstance().getNotificationGroup(CHANGE_STATUS_GROUP)
@@ -108,13 +107,6 @@ class ChangeDependencyRiskStatusAction() : AbstractSonarAction(
                     )
                     null
                 }
-        }
-
-        private fun updateUI(project: Project, newStatus: DependencyRiskTransition, dependencyRisk: LocalDependencyRisk) {
-            runOnUiThread(project) {
-                dependencyRisk.changeStatus(newStatus)
-                getService(project, SonarLintToolWindow::class.java).changeDependencyRiskStatus(dependencyRisk)
-            }
         }
 
         private fun serverConnection(project: Project): ServerConnection? = getService(

--- a/src/main/java/org/sonarlint/intellij/actions/SonarLintToolWindow.java
+++ b/src/main/java/org/sonarlint/intellij/actions/SonarLintToolWindow.java
@@ -342,12 +342,6 @@ public final class SonarLintToolWindow implements ContentManagerListener, Projec
     }
   }
 
-  public void changeDependencyRiskStatus(LocalDependencyRisk risk) {
-    var content = getDependenciesRisksContent();
-    ((DependencyRisksPanel) content.getComponent()).changeStatus(risk);
-    ((DependencyRisksPanel) content.getComponent()).switchCard();
-  }
-
   public void refreshTaintCodeFix() {
     var content = getTaintVulnerabilitiesContent();
     if (content != null) {

--- a/src/main/java/org/sonarlint/intellij/finding/sca/LocalDependencyRisk.kt
+++ b/src/main/java/org/sonarlint/intellij/finding/sca/LocalDependencyRisk.kt
@@ -20,7 +20,6 @@
 package org.sonarlint.intellij.finding.sca
 
 import java.util.UUID
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.sca.DependencyRiskTransition
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.DependencyRiskDto
 
 class LocalDependencyRisk(serverDependencyRisk: DependencyRiskDto) {
@@ -38,14 +37,4 @@ class LocalDependencyRisk(serverDependencyRisk: DependencyRiskDto) {
     fun canChangeStatus(): Boolean {
         return transitions.isNotEmpty()
     }
-
-    fun changeStatus(newStatus: DependencyRiskTransition) {
-        status = when (newStatus) {
-            DependencyRiskTransition.SAFE -> DependencyRiskDto.Status.SAFE
-            DependencyRiskTransition.ACCEPT -> DependencyRiskDto.Status.ACCEPT
-            DependencyRiskTransition.REOPEN -> DependencyRiskDto.Status.OPEN
-            DependencyRiskTransition.CONFIRM -> DependencyRiskDto.Status.CONFIRM
-        }
-    }
-
 }

--- a/src/main/java/org/sonarlint/intellij/ui/risks/DependencyRisksPanel.kt
+++ b/src/main/java/org/sonarlint/intellij/ui/risks/DependencyRisksPanel.kt
@@ -145,14 +145,6 @@ class DependencyRisksPanel(private val project: Project) : SimpleToolWindowPanel
         return cardsPanel
     }
 
-    fun changeStatus(risk: LocalDependencyRisk) {
-        val cache = getService(project, DependencyRisksCache::class.java)
-        val removed = cache.update(risk)
-        if (removed) {
-            updateTrees(cache.dependencyRisks)
-        }
-    }
-
     fun populate(dependencyRisks: List<LocalDependencyRisk>) {
         val cache = getService(project, DependencyRisksCache::class.java)
         cache.dependencyRisks = dependencyRisks


### PR DESCRIPTION
[SLI-2190](https://sonarsource.atlassian.net/browse/SLI-2190)

So that it does not interfere with `didChangeDependencyRisks` callback. Otherwise we don't get correct transitions suggested for a changed item after update.

[SLI-2190]: https://sonarsource.atlassian.net/browse/SLI-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ