### PR TITLE
SLI-2488 Align QA Gradle cache with build job to reduce Repox bandwidth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -675,16 +675,24 @@ jobs:
           path: ${{ github.workspace }}/.intellijPlatform/localPlatformArtifacts
           key: ${{ runner.os }}-jetbrains-ide-${{ matrix.ide_version }}
 
-      - name: Cache Gradle
-        uses: SonarSource/gh-action_cache@v1
+      - name: Generate Gradle Cache Key
+        id: gradle-cache-key
+        run: |
+          /usr/bin/find . \( -name '*.gradle' -o -name '*.gradle.kts' \) -type f -exec md5sum {} \; | sort > gradle-md5-sums.txt
+          md5sum gradle/libs.versions.toml gradle/wrapper/gradle-wrapper.properties 2>/dev/null >> gradle-md5-sums.txt || true
+          GRADLE_CACHE_KEY=$(md5sum gradle-md5-sums.txt | awk '{ print $1 }')
+          echo "key=${GRADLE_CACHE_KEY}" >> "$GITHUB_OUTPUT"
+          rm -f gradle-md5-sums.txt
+
+      - name: Restore Gradle Cache
+        uses: SonarSource/gh-action_cache/restore@v1
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-its-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: gradle-${{ runner.os }}-Build-${{ steps.gradle-cache-key.outputs.key }}
           restore-keys: |
-            ${{ runner.os }}-gradle-its-
-            ${{ runner.os }}-gradle-
+            gradle-${{ runner.os }}-Build-
 
       - name: Cache apt packages
         uses: awalsh128/cache-apt-pkgs-action@latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -685,14 +685,14 @@ jobs:
           rm -f gradle-md5-sums.txt
 
       - name: Restore Gradle Cache
-        uses: SonarSource/gh-action_cache/restore@v1
+        uses: SonarSource/gh-action_cache@v1
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-Build-${{ steps.gradle-cache-key.outputs.key }}
+          key: gradle-${{ runner.os }}-${{ github.workflow }}-${{ steps.gradle-cache-key.outputs.key }}
           restore-keys: |
-            gradle-${{ runner.os }}-Build-
+            gradle-${{ runner.os }}-${{ github.workflow }}-
 
       - name: Cache apt packages
         uses: awalsh128/cache-apt-pkgs-action@latest


### PR DESCRIPTION
## Summary

- Aligns the 21 QA matrix jobs' Gradle cache key with the pattern used by `ci-github-actions/config-gradle` in the `build-plugin` job
- QA jobs currently use key `{os}-gradle-its-{hashFiles}` while build jobs use `gradle-{os}-{workflow}-{md5}` — these never match, so QA jobs independently resolve the full Gradle dependency tree from Repox
- Uses the same `md5sum`-based key generation as `ci-github-actions/config-gradle` and `${{ github.workflow }}` to dynamically match the workflow name
- Cache save is a no-op in QA jobs since the key already exists from `build-plugin`

## Context

`sonarlint-intellij` is the #1 Repox bandwidth consumer at **963 GB/week** (22.76% of total). Each of the 21 QA matrix jobs independently resolves Gradle dependencies because their cache key pattern doesn't match the build job's cache.

**Note:** `SonarSource/gh-action_cache` uses S3-backed storage with branch-scoped keys for private repos. The key alignment works because both `build-plugin` and QA jobs run in the same workflow on the same branch, so the S3 prefix (`{branch}/{key}`) matches.

## Verified impact

**PR CI run:** https://github.com/SonarSource/sonarlint-intellij/actions/runs/21900563639
**Baseline (master):** https://github.com/SonarSource/sonarlint-intellij/actions/runs/21840637770

### Cache key alignment — confirmed

| Job | Cache Key |
|-----|-----------|
| build-plugin | `gradle-Linux-Build-69356b268a8b3a89b47307e4d0dc44e4` |
| QA (CLion2023) | `gradle-Linux-Build-69356b268a8b3a89b47307e4d0dc44e4` |

Exact match across build and QA jobs.

### Download reduction — 71% fewer Repox downloads per QA job

Baseline comparison using CLion2023 QA job — [master](https://github.com/SonarSource/sonarlint-intellij/actions/runs/21840637770/job/63024772005) vs [this PR](https://github.com/SonarSource/sonarlint-intellij/actions/runs/21900563639/job/63228347951):

| Metric | Master | This PR | Change |
|--------|--------|---------|--------|
| Deps from local cache | 70 | 319 | +249 (+356%) |
| Downloads from Repox | 791 | 229 | **-562 (-71%)** |
| JAR downloads | 244 | 77 | -167 (-68%) |
| Metadata downloads (.pom/.module) | 547 | 152 | -395 (-72%) |
| Gradle cache restored from S3 | none (miss) | 2.47 GB | new |

On master, the QA cache key `Linux-gradle-its-{hash}` never matches the build job's `gradle-Linux-Build-{hash}`, resulting in a cache miss every time.

### Post-job cache save — no redundant uploads

```
Cache hit occurred on the primary key gradle-Linux-Build-69356b268a8b3a89b47307e4d0dc44e4, not saving cache.
```

All 21 QA jobs skip re-uploading the 2.47 GB cache since the key already exists.

### Remaining downloads — expected

The 229 remaining downloads are `:its`-specific dependencies (IntelliJ test-framework, orchestrator, etc.) not present in the build cache because `build-plugin` runs with `-x :its:check`. These still resolve from Repox as before.

### Estimated bandwidth savings

| | Before | After | Change |
|---|--------|-------|--------|
| Per QA job | ~1.44 GB | ~0.42 GB | -1.02 GB |
| Per build (21 jobs) | ~30 GB | ~8.8 GB | -21.2 GB |
| Per week (~28.5 builds) | ~860 GB | ~250 GB | **-610 GB/week** |
| **Total repo weekly** | **963 GB/week** | **~350 GB/week** | **-63%** |
| **Monthly** | ~4.1 TB | ~1.5 TB | **-2.6 TB/month saved** |

This recovers ~4.3% of the 60 TB/month Repox contract from a single repo.

### Test failures — pre-existing, unrelated to cache change

2/21 QA jobs failed. Both are pre-existing flaky tests (also seen on [master run from Feb 5](https://github.com/SonarSource/sonarlint-intellij/actions/runs/21714832128)):

| Test | Job | Root Cause |
|------|-----|-----------|
| OpenInIdeTests (IC-2025.2) | [link](https://github.com/SonarSource/sonarlint-intellij/actions/runs/21900563639/job/63228347809) | UI automation timeout: "Failed on step: Search 'Idea frame'" |
| PhpStorm2023 (PS-2023.1.6) | [link](https://github.com/SonarSource/sonarlint-intellij/actions/runs/21900563639/job/63228347930) | "Timeout waiting for IDE to start" — IDE never booted |

Neither failure is related to Gradle dependency resolution or caching.

## How to verify

**In this PR's CI run:**
1. Check [build-plugin](https://github.com/SonarSource/sonarlint-intellij/actions/runs/21900563639) job logs → cache save with key `gradle-Linux-Build-{hash}`
2. Check any QA job (e.g. [CLion2023](https://github.com/SonarSource/sonarlint-intellij/actions/runs/21900563639/job/63228347951)) → `key: gradle-Linux-Build-{hash}` in the "Restore Gradle Cache" step
3. Post-job cleanup → "Cache hit occurred on the primary key ..., not saving cache."
4. QA tests pass (excluding known flaky tests above)

**After merge (bandwidth measurement):**
```
Datadog query: sum:artifactory.response.length.bytes{usr.name:vault-sonarsource-sonarlint-intellij-qa-deployer}.as_count()
Dashboard: https://app.datadoghq.eu/dashboard/tgr-9ku-3d8
```
Compare the week before merge vs. the week after. Expected: ~60% reduction for this token.

## Test plan

- [x] QA jobs show cache hit in logs (key matches `build-plugin`)
- [x] Cache save is no-op in QA jobs (no redundant 2.47 GB uploads)
- [x] No new Repox errors or missing dependency failures
- [x] Baseline comparison confirms 71% fewer downloads vs master
- [ ] 2 flaky QA failures (OpenInIdeTests, PhpStorm2023) confirmed pre-existing on master
- [ ] Post-merge: Datadog shows ~60% bandwidth reduction for sonarlint-intellij

🤖 Generated with [Claude Code](https://claude.com/claude-code)