### PR TITLE
SLI-2606 Fix failing shadow scan CI

### DIFF
--- a/.github/workflows/shadow_scans.yml
+++ b/.github/workflows/shadow_scans.yml
@@ -74,6 +74,14 @@ jobs:
           artifactory-deployer-role: qa-deployer
           gradle-args: -x :its:check -x :buildPlugin -x :cyclonedxBom check jacocoTestReport
 
+  iris:
+    needs: scan
+    runs-on: github-ubuntu-latest-m
+    name: Run IRIS Analysis
+    permissions:
+      id-token: write
+      contents: read
+    steps:
       - name: Run IRIS Analysis
         uses: SonarSource/unified-dogfooding-actions/run-iris@v1
         with:


### PR DESCRIPTION
Following recent refactoring, the CI step was moved to a container, breaking IRIS scan. We should put this one in a separate task, not running in a container.