### PR TITLE
SLI-2707 Remove usage of internal method on 262.x (EAP)

### DIFF
--- a/src/main/java/org/sonarlint/intellij/SonarLintPlugin.java
+++ b/src/main/java/org/sonarlint/intellij/SonarLintPlugin.java
@@ -19,15 +19,18 @@
  */
 package org.sonarlint.intellij;
 
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.components.Service;
+import com.intellij.openapi.extensions.PluginDescriptor;
 import com.intellij.openapi.extensions.PluginId;
 import java.nio.file.Path;
+import org.jetbrains.annotations.NotNull;
 
 @Service(Service.Level.APP)
 public final class SonarLintPlugin {
-  private IdeaPluginDescriptor plugin;
+  private static final PluginId PLUGIN_ID = PluginId.getId("org.sonarlint.idea");
+
+  private PluginDescriptor plugin;
 
   public String getVersion() {
     return getPlugin().getVersion();
@@ -37,9 +40,12 @@ public final class SonarLintPlugin {
     return getPlugin().getPluginPath();
   }
 
-  private IdeaPluginDescriptor getPlugin() {
+  private @NotNull PluginDescriptor getPlugin() {
     if (plugin == null) {
-      plugin = PluginManagerCore.getPlugin(PluginId.getId("org.sonarlint.idea"));
+      plugin = PluginManager.getInstance().findEnabledPlugin(PLUGIN_ID);
+      if (plugin == null) {
+        throw new IllegalStateException("Cannot find SonarLint plugin descriptor (id=" + PLUGIN_ID + ")");
+      }
     }
     return plugin;
   }

--- a/src/main/java/org/sonarlint/intellij/core/EnabledLanguages.kt
+++ b/src/main/java/org/sonarlint/intellij/core/EnabledLanguages.kt
@@ -19,7 +19,7 @@
  */
 package org.sonarlint.intellij.core
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.extensions.PluginId
 import java.io.IOException
 import java.nio.file.Files
@@ -188,5 +188,6 @@ object EnabledLanguages {
     @JvmStatic
     fun isClionEnabled() = isIdeModuleEnabled(CLION_MODULE_ID)
 
-    private fun isIdeModuleEnabled(pluginId: String) = PluginManagerCore.getPlugin(PluginId.getId(pluginId))?.isEnabled == true
+    private fun isIdeModuleEnabled(pluginId: String) =
+        PluginManager.getInstance().findEnabledPlugin(PluginId.getId(pluginId)) != null
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **API Compatibility:**
  - Replaced internal usage of `PluginManagerCore` with `PluginManager` to support IntelliJ 262.x (EAP).
  - Updated `SonarLintPlugin` and `EnabledLanguages` to use standard plugin discovery APIs instead of restricted internal methods.

<sub>This will update automatically on new commits.</sub>