### PR TITLE
SLI-2706 Fix flaky OpenInIdeTests caused by SonarCloud issue indexing delay

### DIFF
--- a/its/src/test/kotlin/org/sonarlint/intellij/its/tests/ConfigurationTests.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/tests/ConfigurationTests.kt
@@ -61,6 +61,7 @@ import org.sonarlint.intellij.its.utils.SonarCloudUtils.SONARCLOUD_STAGING_URL
 import org.sonarlint.intellij.its.utils.SonarCloudUtils.analyzeSonarCloudWithMaven
 import org.sonarlint.intellij.its.utils.SonarCloudUtils.associateSonarCloudProjectToQualityProfile
 import org.sonarlint.intellij.its.utils.SonarCloudUtils.cleanupProjects
+import org.sonarlint.intellij.its.utils.SonarCloudUtils.getFirstSonarCloudIssueKey
 import org.sonarlint.intellij.its.utils.SonarCloudUtils.newAdminSonarCloudWsClientWithUser
 import org.sonarlint.intellij.its.utils.SonarCloudUtils.provisionSonarCloudProfile
 import org.sonarlint.intellij.its.utils.SonarCloudUtils.restoreSonarCloudProfile
@@ -115,14 +116,6 @@ class ConfigurationTests : BaseUiTest() {
         private fun getFirstIssueKey(client: WsClient, projectKey: String): String? {
             val searchRequest = SearchRequest()
             searchRequest.projects = listOf(projectKey)
-            val searchResults = client.issues().search(searchRequest)
-            val issue = searchResults.issuesList[0]
-            return issue.key
-        }
-
-        private fun getFirstSCIssueKey(client: WsClient): String? {
-            val searchRequest = SearchRequest()
-            searchRequest.projects = listOf(SONARCLOUD_ISSUE_PROJECT_KEY)
             val searchResults = client.issues().search(searchRequest)
             val issue = searchResults.issuesList[0]
             return issue.key
@@ -307,7 +300,7 @@ class ConfigurationTests : BaseUiTest() {
             )
 
             analyzeSonarCloudWithMaven(adminSonarCloudWsClient, SONARCLOUD_ISSUE_PROJECT_KEY, "sli-java-issues", sonarCloudToken)
-            firstSCIssueKey = getFirstSCIssueKey(adminSonarCloudWsClient)
+            firstSCIssueKey = getFirstSonarCloudIssueKey(adminSonarCloudWsClient, SONARCLOUD_ISSUE_PROJECT_KEY)
         }
 
         @Test

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/tests/OpenInIdeTests.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/tests/OpenInIdeTests.kt
@@ -68,6 +68,7 @@ import org.sonarlint.intellij.its.utils.SonarCloudUtils.SONARCLOUD_STAGING_URL
 import org.sonarlint.intellij.its.utils.SonarCloudUtils.analyzeSonarCloudWithMaven
 import org.sonarlint.intellij.its.utils.SonarCloudUtils.associateSonarCloudProjectToQualityProfile
 import org.sonarlint.intellij.its.utils.SonarCloudUtils.cleanupProjects
+import org.sonarlint.intellij.its.utils.SonarCloudUtils.getFirstSonarCloudIssueKey
 import org.sonarlint.intellij.its.utils.SonarCloudUtils.newAdminSonarCloudWsClientWithUser
 import org.sonarlint.intellij.its.utils.SonarCloudUtils.provisionSonarCloudProfile
 import org.sonarlint.intellij.its.utils.SonarCloudUtils.restoreSonarCloudProfile
@@ -126,14 +127,6 @@ class OpenInIdeTests : BaseUiTest() {
         private fun getFirstIssueKey(client: WsClient): String? {
             val searchRequest = SearchRequest()
             searchRequest.projects = listOf(ISSUE_PROJECT_KEY)
-            val searchResults = client.issues().search(searchRequest)
-            val issue = searchResults.issuesList[0]
-            return issue.key
-        }
-
-        private fun getFirstSCIssueKey(client: WsClient): String? {
-            val searchRequest = SearchRequest()
-            searchRequest.projects = listOf(SONARCLOUD_ISSUE_PROJECT_KEY)
             val searchResults = client.issues().search(searchRequest)
             val issue = searchResults.issuesList[0]
             return issue.key
@@ -222,7 +215,9 @@ class OpenInIdeTests : BaseUiTest() {
             // Build and analyze project to raise issue
             executeBuildWithMaven("projects/sli-java-issues/pom.xml", ORCHESTRATOR)
             firstIssueKey = getFirstIssueKey(adminWsClient)
+        }
 
+        private fun prepareSonarCloudIssueProject() {
             restoreSonarCloudProfile(adminSonarCloudWsClient, "java-sonarlint-with-issue.xml")
             provisionSonarCloudProfile(adminSonarCloudWsClient, ISSUE_PROJECT_KEY, SONARCLOUD_ISSUE_PROJECT_KEY)
             associateSonarCloudProjectToQualityProfile(
@@ -231,15 +226,14 @@ class OpenInIdeTests : BaseUiTest() {
                 SONARCLOUD_ISSUE_PROJECT_KEY,
                 "SonarLint IT Java Issue"
             )
-
             analyzeSonarCloudWithMaven(adminSonarCloudWsClient, SONARCLOUD_ISSUE_PROJECT_KEY, "sli-java-issues", sonarCloudToken)
-
-            firstSCIssueKey = getFirstSCIssueKey(adminSonarCloudWsClient)
+            firstSCIssueKey = getFirstSonarCloudIssueKey(adminSonarCloudWsClient, SONARCLOUD_ISSUE_PROJECT_KEY)
         }
 
         @Disabled("Doesn't find the project")
         @Test
         fun click_open_in_ide_SC_issue_then_should_automatically_create_connection_then_should_automatically_bind() = uiTest {
+            prepareSonarCloudIssueProject()
             clearConnections()
             openExistingProject(ISSUE_PROJECT_KEY)
             triggerOpenSCIssueRequest(

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/utils/SonarCloudUtils.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/utils/SonarCloudUtils.kt
@@ -35,6 +35,7 @@ import org.sonarqube.ws.client.HttpConnector
 import org.sonarqube.ws.client.PostRequest
 import org.sonarqube.ws.client.WsClient
 import org.sonarqube.ws.client.WsClientFactories
+import org.sonarqube.ws.client.issues.SearchRequest
 
 object SonarCloudUtils {
 
@@ -76,8 +77,22 @@ object SonarCloudUtils {
                 "true" == response.content()
             }
         }
-        // Once the queue is empty, wait one more second as it can sometimes happen that issue cannot be yet fetched from SQ:C
-        Thread.sleep(1000)
+        waitForSonarCloudIssues(adminWsClient, projectKey)
+    }
+
+    fun waitForSonarCloudIssues(adminWsClient: WsClient, projectKey: String) {
+        waitFor(Duration.ofMinutes(2), interval = Duration.ofSeconds(5)) {
+            val searchRequest = SearchRequest()
+            searchRequest.projects = listOf(projectKey)
+            adminWsClient.issues().search(searchRequest).issuesList.isNotEmpty()
+        }
+    }
+
+    fun getFirstSonarCloudIssueKey(adminWsClient: WsClient, projectKey: String): String {
+        waitForSonarCloudIssues(adminWsClient, projectKey)
+        val searchRequest = SearchRequest()
+        searchRequest.projects = listOf(projectKey)
+        return adminWsClient.issues().search(searchRequest).issuesList.first().key
     }
 
     fun restoreSonarCloudProfile(adminWsClient: WsClient, fileName: String) {


### PR DESCRIPTION
----
## Summary by Gitar

- **Test stability improvements:**
  - Replaced hardcoded `Thread.sleep` with a polling mechanism in `SonarCloudUtils` to wait for issue indexing.
  - Centralized issue retrieval logic using `getFirstSonarCloudIssueKey` to ensure tests don't proceed before issues are available.

<sub>This will update automatically on new commits.</sub>