### PR TITLE
SLI-2710 Fix CheckDependencies failure caused by its module Maven group

### DIFF
--- a/its/build.gradle.kts
+++ b/its/build.gradle.kts
@@ -18,7 +18,6 @@ dependencyLocking {
 val intellijBuildVersion: String by project
 val ijVersion: String by project
 val runIdeDirectory: String by project
-group = "org.sonarsource.sonarlint.intellij.its"
 description = "ITs for SonarLint IntelliJ"
 
 java {


### PR DESCRIPTION
----
## Summary by Gitar

- **Build configuration:**
  - Removed an incorrect dependency declaration in `its/build.gradle.kts` to resolve a Maven group ID failure.

<sub>This will update automatically on new commits.</sub>