### PR TITLE
SLI-2716 Fix duplicate issues in Problems view for cshtml and razor files in Rider

### DIFF
--- a/common/src/main/java/org/sonarlint/intellij/common/util/SonarLintUtils.java
+++ b/common/src/main/java/org/sonarlint/intellij/common/util/SonarLintUtils.java
@@ -163,6 +163,15 @@ public class SonarLintUtils {
     return "php".equalsIgnoreCase(file.getFileType().getName());
   }
 
+  public static boolean isRazorFile(@NotNull PsiFile file) {
+    var virtualFile = file.getVirtualFile();
+    if (virtualFile == null) {
+      return false;
+    }
+    var ext = virtualFile.getExtension();
+    return "cshtml".equalsIgnoreCase(ext) || "razor".equalsIgnoreCase(ext);
+  }
+
   private static ApplicationInfo getAppInfo() {
     return ApplicationInfo.getInstance();
   }

--- a/src/main/java/org/sonarlint/intellij/editor/SonarExternalAnnotator.java
+++ b/src/main/java/org/sonarlint/intellij/editor/SonarExternalAnnotator.java
@@ -94,9 +94,19 @@ public class SonarExternalAnnotator extends ExternalAnnotator<SonarExternalAnnot
       .forEach(vulnerability -> addAnnotation(vulnerability, fileTextRange, holder));
   }
 
-  private static boolean shouldSkip(PsiFile file) {
+  static boolean shouldSkip(PsiFile file) {
     // A php file is annotated twice, once by HTML and once by PHP plugin. We want to avoid duplicate annotation
-    return isPhpLanguageRegistered() && isPhpFile(file);
+    if (isPhpLanguageRegistered() && isPhpFile(file)) {
+      return true;
+    }
+    // cshtml and razor files in Rider trigger apply() for multiple embedded languages (C#, HTML dialect, and Razor/Blazor).
+    // Keep only the Razor fileType pass to avoid duplicate annotations in the Problems view.
+    var virtualFile = file.getVirtualFile();
+    if (virtualFile != null) {
+      var ext = virtualFile.getExtension();
+      return ("cshtml".equalsIgnoreCase(ext) || "razor".equalsIgnoreCase(ext)) && !"Razor".equalsIgnoreCase(file.getFileType().getName());
+    }
+    return false;
   }
 
   @Override

--- a/src/main/java/org/sonarlint/intellij/editor/SonarExternalAnnotator.java
+++ b/src/main/java/org/sonarlint/intellij/editor/SonarExternalAnnotator.java
@@ -49,6 +49,8 @@ import org.sonarsource.sonarlint.core.rpc.protocol.common.IssueSeverity;
 import static org.sonarlint.intellij.common.util.SonarLintUtils.getService;
 import static org.sonarlint.intellij.common.util.SonarLintUtils.isPhpFile;
 import static org.sonarlint.intellij.common.util.SonarLintUtils.isPhpLanguageRegistered;
+import static org.sonarlint.intellij.common.util.SonarLintUtils.isRazorFile;
+import static org.sonarlint.intellij.common.util.SonarLintUtils.isRider;
 import static org.sonarlint.intellij.config.Settings.getSettingsFor;
 
 public class SonarExternalAnnotator extends ExternalAnnotator<SonarExternalAnnotator.AnnotationContext, SonarExternalAnnotator.AnnotationContext> {
@@ -101,10 +103,8 @@ public class SonarExternalAnnotator extends ExternalAnnotator<SonarExternalAnnot
     }
     // cshtml and razor files in Rider trigger apply() for multiple embedded languages (C#, HTML dialect, and Razor/Blazor).
     // Keep only the Razor fileType pass to avoid duplicate annotations in the Problems view.
-    var virtualFile = file.getVirtualFile();
-    if (virtualFile != null) {
-      var ext = virtualFile.getExtension();
-      return ("cshtml".equalsIgnoreCase(ext) || "razor".equalsIgnoreCase(ext)) && !"Razor".equalsIgnoreCase(file.getFileType().getName());
+    if (isRider() && isRazorFile(file)) {
+      return !"Razor".equalsIgnoreCase(file.getFileType().getName());
     }
     return false;
   }

--- a/src/test/java/org/sonarlint/intellij/editor/SonarExternalAnnotatorTests.java
+++ b/src/test/java/org/sonarlint/intellij/editor/SonarExternalAnnotatorTests.java
@@ -20,11 +20,14 @@
 package org.sonarlint.intellij.editor;
 
 import com.intellij.ide.highlighter.JavaFileType;
+import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.sonarlint.intellij.AbstractSonarLintLightTests;
 import org.sonarlint.intellij.config.Settings;
 import org.sonarlint.intellij.config.SonarLintTextAttributes;
@@ -48,6 +51,26 @@ class SonarExternalAnnotatorTests extends AbstractSonarLintLightTests {
     when(psiFile.getFileType()).thenReturn(JavaFileType.INSTANCE);
     when(psiFile.getProject()).thenReturn(getProject());
     Settings.getGlobalSettings().setFocusOnNewCode(false);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "cshtml, C#,    true",
+    "cshtml, HTML,  true",
+    "cshtml, Razor, false",
+    "cshtml, razor, false",
+    "razor,  C#,    true",
+    "razor,  Razor, false",
+    "razor,  RAZOR, false",
+    "cs,     C#,    false"
+  })
+  void shouldSkip_razorAndCshtmlFiles(String extension, String fileTypeName, boolean expectedShouldSkip) {
+    var fileType = mock(FileType.class);
+    when(fileType.getName()).thenReturn(fileTypeName);
+    when(psiFile.getFileType()).thenReturn(fileType);
+    when(virtualFile.getExtension()).thenReturn(extension);
+
+    assertThat(SonarExternalAnnotator.shouldSkip(psiFile)).isEqualTo(expectedShouldSkip);
   }
 
   @Test

--- a/src/test/java/org/sonarlint/intellij/editor/SonarExternalAnnotatorTests.java
+++ b/src/test/java/org/sonarlint/intellij/editor/SonarExternalAnnotatorTests.java
@@ -35,8 +35,11 @@ import org.sonarlint.intellij.config.global.ServerConnection;
 import org.sonarsource.sonarlint.core.client.utils.ImpactSeverity;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.IssueSeverity;
 
+import org.sonarlint.intellij.common.util.SonarLintUtils;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 class SonarExternalAnnotatorTests extends AbstractSonarLintLightTests {
@@ -70,7 +73,10 @@ class SonarExternalAnnotatorTests extends AbstractSonarLintLightTests {
     when(psiFile.getFileType()).thenReturn(fileType);
     when(virtualFile.getExtension()).thenReturn(extension);
 
-    assertThat(SonarExternalAnnotator.shouldSkip(psiFile)).isEqualTo(expectedShouldSkip);
+    try (var mockedUtils = mockStatic(SonarLintUtils.class, org.mockito.Mockito.CALLS_REAL_METHODS)) {
+      mockedUtils.when(SonarLintUtils::isRider).thenReturn(true);
+      assertThat(SonarExternalAnnotator.shouldSkip(psiFile)).isEqualTo(expectedShouldSkip);
+    }
   }
 
   @Test


### PR DESCRIPTION
Source of issue: https://community.sonarsource.com/t/duplicated-issues-in-problems-view-in-rider/182780

----
## Summary by Gitar

- **Bug fix:**
  - Modified `SonarExternalAnnotator.shouldSkip` to prevent duplicate annotations for `cshtml` and `razor` files in Rider.
- **Testing:**
  - Added parameterized tests in `SonarExternalAnnotatorTests` to verify skip logic for various file extensions and types.

<sub>This will update automatically on new commits.</sub>