### PR TITLE
test: run Windows check on ci-ami-images PR #367 temp runner (nuget feed)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
         run: echo "project-version=${PROJECT_VERSION}" >> $GITHUB_OUTPUT
 
   check_windows:
-    runs-on: warp-custom-sonarlint-intellij
+    runs-on: warp-custom-pr-367-sonarlint-intellij-v20260615143319
     needs: build-number
     name: Test Windows
     env:


### PR DESCRIPTION
----
## Summary by Gitar

- **CI Configuration:**
  - Updated `check_windows` job to use temporary runner `warp-custom-pr-367-sonarlint-intellij-v20260615143319` for NuGet feed testing.

<sub>This will update automatically on new commits.</sub>