### PR TITLE
SLI-2720 Fix IDE UI freezes caused by non-cancellable read actions

### DIFF
--- a/common/src/main/java/org/sonarlint/intellij/common/ui/ReadActionUtils.kt
+++ b/common/src/main/java/org/sonarlint/intellij/common/ui/ReadActionUtils.kt
@@ -20,8 +20,10 @@
 package org.sonarlint.intellij.common.ui
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.NonBlockingReadAction
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Computable
@@ -39,6 +41,10 @@ import java.util.concurrent.Callable
  *
  * - **Background thread** → [ReadAction.nonBlocking] (cancellable; expires when the project is disposed)
  * - **EDT** → [ReadAction.compute] / [ReadAction.run] ([ReadAction.nonBlocking] must not run on EDT)
+ *
+ * On background threads, cancellation or project expiration returns `null` (compute) or no-ops (run)
+ * instead of throwing [ProcessCanceledException]. Non-blocking read actions may re-run their lambda
+ * after cancellation; keep read-action bodies idempotent and free of non-repeatable side effects.
  *
  * Prefer these methods over calling [ReadAction] directly.
  */
@@ -112,10 +118,11 @@ class ReadActionUtils {
                 return if (ApplicationManager.getApplication().isDispatchThread) {
                     DumbService.getInstance(project).runReadActionInSmartMode(action)
                 } else {
-                    ReadAction.nonBlocking(Callable { action.compute() })
-                        .inSmartMode(project)
-                        .expireWhen { project.isDisposed || !virtualFile.isValid }
-                        .executeSynchronously()
+                    executeNonBlockingReadAction(
+                        ReadAction.nonBlocking(Callable { action.compute() })
+                            .inSmartMode(project)
+                            .expireWhen { project.isDisposed || !virtualFile.isValid }
+                    )
                 }
             }
             return null
@@ -139,7 +146,7 @@ class ReadActionUtils {
                 if (project != null) {
                     readAction = readAction.expireWhen { project.isDisposed }
                 }
-                readAction.executeSynchronously()
+                executeNonBlockingReadAction(readAction)
             }
         }
 
@@ -154,7 +161,7 @@ class ReadActionUtils {
             if (projectForExpiration != null) {
                 readAction = readAction.expireWhen { projectForExpiration.isDisposed }
             }
-            return readAction.executeSynchronously()
+            return executeNonBlockingReadAction(readAction)
         }
 
         private fun <T> computeCancellableReadAction(action: ThrowableComputable<T, out Exception>): T {
@@ -162,6 +169,18 @@ class ReadActionUtils {
                 ReadAction.compute<T, Exception> { action.compute() }
             } else {
                 ReadAction.nonBlocking(Callable { action.compute() }).executeSynchronously()
+            }
+        }
+
+        /**
+         * Runs a non-blocking read action on a background thread.
+         * Returns null when the action is cancelled or expired — intentional boundary for *Safely* helpers.
+         */
+        private fun <T> executeNonBlockingReadAction(readAction: NonBlockingReadAction<T>): T? {
+            return try {
+                readAction.executeSynchronously()
+            } catch (_: ProcessCanceledException) {
+                null
             }
         }
     }

--- a/common/src/main/java/org/sonarlint/intellij/common/ui/ReadActionUtils.kt
+++ b/common/src/main/java/org/sonarlint/intellij/common/ui/ReadActionUtils.kt
@@ -39,7 +39,7 @@ import java.util.concurrent.Callable
  * prevent the EDT from writing and freeze the UI. This class picks the appropriate API
  * based on the current thread.
  *
- * - **Background thread** → [ReadAction.nonBlocking] (cancellable; expires when the project is disposed)
+ * - **Background thread** → [ReadAction.nonBlocking] (cancellable; expires when the project or [VirtualFile] is disposed/invalid)
  * - **EDT** → [ReadAction.compute] / [ReadAction.run] ([ReadAction.nonBlocking] must not run on EDT)
  *
  * On background threads, cancellation or project expiration returns `null` (compute) or no-ops (run)
@@ -101,7 +101,7 @@ class ReadActionUtils {
         @JvmStatic
         fun <T> computeReadActionSafely(virtualFile: VirtualFile, project: Project, action: ThrowableComputable<T, out Exception>): T? {
             if (!project.isDisposed) {
-                return computeCancellableReadAction(project) {
+                return computeCancellableReadAction(project, virtualFile) {
                     if (project.isDisposed || !virtualFile.isValid) null else action.compute()
                 }
             }
@@ -130,7 +130,7 @@ class ReadActionUtils {
 
         @JvmStatic
         fun <T> computeReadActionSafely(virtualFile: VirtualFile, action: ThrowableComputable<T, out Exception>): T? {
-            return computeCancellableReadAction {
+            return computeCancellableReadAction(virtualFileForExpiration = virtualFile) {
                 if (!virtualFile.isValid) null else action.compute()
             }
         }
@@ -152,14 +152,18 @@ class ReadActionUtils {
 
         private fun <T> computeCancellableReadAction(
             projectForExpiration: Project? = null,
+            virtualFileForExpiration: VirtualFile? = null,
             action: ThrowableComputable<T?, out Exception>,
         ): T? {
             if (ApplicationManager.getApplication().isDispatchThread) {
                 return ReadAction.compute<T?, Exception> { action.compute() }
             }
             var readAction = ReadAction.nonBlocking(Callable { action.compute() })
-            if (projectForExpiration != null) {
-                readAction = readAction.expireWhen { projectForExpiration.isDisposed }
+            if (projectForExpiration != null || virtualFileForExpiration != null) {
+                readAction = readAction.expireWhen {
+                    projectForExpiration?.isDisposed == true
+                        || (virtualFileForExpiration != null && !virtualFileForExpiration.isValid)
+                }
             }
             return executeNonBlockingReadAction(readAction)
         }

--- a/common/src/main/java/org/sonarlint/intellij/common/ui/ReadActionUtils.kt
+++ b/common/src/main/java/org/sonarlint/intellij/common/ui/ReadActionUtils.kt
@@ -19,6 +19,7 @@
  */
 package org.sonarlint.intellij.common.ui
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.DumbService
@@ -27,13 +28,26 @@ import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.ThrowableComputable
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
+import java.util.concurrent.Callable
 
+/**
+ * Thread-aware read-action helpers for PSI/VFS access.
+ *
+ * Long-running read actions on a background thread must be cancellable: otherwise they can
+ * prevent the EDT from writing and freeze the UI. This class picks the appropriate API
+ * based on the current thread.
+ *
+ * - **Background thread** → [ReadAction.nonBlocking] (cancellable; expires when the project is disposed)
+ * - **EDT** → [ReadAction.compute] / [ReadAction.run] ([ReadAction.nonBlocking] must not run on EDT)
+ *
+ * Prefer these methods over calling [ReadAction] directly.
+ */
 class ReadActionUtils {
     companion object {
         @JvmStatic
         fun runReadActionSafely(project: Project, action: Runnable) {
             if (!project.isDisposed) {
-                return ReadAction.run<Exception> {
+                runCancellableReadAction(project) {
                     if (!project.isDisposed) action.run()
                 }
             }
@@ -41,22 +55,20 @@ class ReadActionUtils {
 
         @JvmStatic
         fun runReadActionSafely(action: Runnable) {
-            return ReadAction.run<Exception> {
+            runCancellableReadAction {
                 action.run()
             }
         }
 
         @JvmStatic
         fun <T> computeReadActionSafely(action: ThrowableComputable<T, out Exception>): T {
-            return ReadAction.compute<T, Exception> {
-                action.compute()
-            }
+            return computeCancellableReadAction(action = action)
         }
 
         @JvmStatic
         fun <T> computeReadActionSafely(project: Project, action: ThrowableComputable<T, out Exception>): T? {
             if (!project.isDisposed) {
-                return ReadAction.compute<T?, Exception> {
+                return computeCancellableReadAction(project) {
                     if (project.isDisposed) null else action.compute()
                 }
             }
@@ -66,7 +78,7 @@ class ReadActionUtils {
         @JvmStatic
         fun <T> computeReadActionSafely(module: Module, action: ThrowableComputable<T, out Exception>): T? {
             if (!module.isDisposed) {
-                return ReadAction.compute<T?, Exception> {
+                return computeCancellableReadAction(module.project) {
                     if (module.isDisposed) null else action.compute()
                 }
             }
@@ -75,7 +87,7 @@ class ReadActionUtils {
 
         @JvmStatic
         fun <T> computeReadActionSafely(psiFile: PsiFile, action: ThrowableComputable<T, out Exception>): T? {
-            return ReadAction.compute<T?, Exception> {
+            return computeCancellableReadAction(psiFile.project) {
                 if (!psiFile.isValid) null else action.compute()
             }
         }
@@ -83,7 +95,7 @@ class ReadActionUtils {
         @JvmStatic
         fun <T> computeReadActionSafely(virtualFile: VirtualFile, project: Project, action: ThrowableComputable<T, out Exception>): T? {
             if (!project.isDisposed) {
-                return ReadAction.compute<T, Exception> {
+                return computeCancellableReadAction(project) {
                     if (project.isDisposed || !virtualFile.isValid) null else action.compute()
                 }
             }
@@ -97,15 +109,59 @@ class ReadActionUtils {
             action: Computable<T>
         ): T? {
             if (!project.isDisposed && virtualFile.isValid) {
-                return DumbService.getInstance(project).runReadActionInSmartMode(action)
+                return if (ApplicationManager.getApplication().isDispatchThread) {
+                    DumbService.getInstance(project).runReadActionInSmartMode(action)
+                } else {
+                    ReadAction.nonBlocking(Callable { action.compute() })
+                        .inSmartMode(project)
+                        .expireWhen { project.isDisposed || !virtualFile.isValid }
+                        .executeSynchronously()
+                }
             }
             return null
         }
 
         @JvmStatic
         fun <T> computeReadActionSafely(virtualFile: VirtualFile, action: ThrowableComputable<T, out Exception>): T? {
-            return ReadAction.compute<T?, Exception> {
+            return computeCancellableReadAction {
                 if (!virtualFile.isValid) null else action.compute()
+            }
+        }
+
+        private fun runCancellableReadAction(project: Project? = null, action: Runnable) {
+            if (ApplicationManager.getApplication().isDispatchThread) {
+                ReadAction.run<Exception> { action.run() }
+            } else {
+                var readAction = ReadAction.nonBlocking(Callable {
+                    action.run()
+                    null
+                })
+                if (project != null) {
+                    readAction = readAction.expireWhen { project.isDisposed }
+                }
+                readAction.executeSynchronously()
+            }
+        }
+
+        private fun <T> computeCancellableReadAction(
+            projectForExpiration: Project? = null,
+            action: ThrowableComputable<T?, out Exception>,
+        ): T? {
+            if (ApplicationManager.getApplication().isDispatchThread) {
+                return ReadAction.compute<T?, Exception> { action.compute() }
+            }
+            var readAction = ReadAction.nonBlocking(Callable { action.compute() })
+            if (projectForExpiration != null) {
+                readAction = readAction.expireWhen { projectForExpiration.isDisposed }
+            }
+            return readAction.executeSynchronously()
+        }
+
+        private fun <T> computeCancellableReadAction(action: ThrowableComputable<T, out Exception>): T {
+            return if (ApplicationManager.getApplication().isDispatchThread) {
+                ReadAction.compute<T, Exception> { action.compute() }
+            } else {
+                ReadAction.nonBlocking(Callable { action.compute() }).executeSynchronously()
             }
         }
     }

--- a/common/src/main/java/org/sonarlint/intellij/common/ui/ReadActionUtils.kt
+++ b/common/src/main/java/org/sonarlint/intellij/common/ui/ReadActionUtils.kt
@@ -67,8 +67,8 @@ class ReadActionUtils {
         }
 
         @JvmStatic
-        fun <T> computeReadActionSafely(action: ThrowableComputable<T, out Exception>): T {
-            return computeCancellableReadAction(action = action)
+        fun <T> computeReadActionSafely(action: ThrowableComputable<T, out Exception>): T? {
+            return computeCancellableReadAction { action.compute() }
         }
 
         @JvmStatic
@@ -162,14 +162,6 @@ class ReadActionUtils {
                 readAction = readAction.expireWhen { projectForExpiration.isDisposed }
             }
             return executeNonBlockingReadAction(readAction)
-        }
-
-        private fun <T> computeCancellableReadAction(action: ThrowableComputable<T, out Exception>): T {
-            return if (ApplicationManager.getApplication().isDispatchThread) {
-                ReadAction.compute<T, Exception> { action.compute() }
-            } else {
-                ReadAction.nonBlocking(Callable { action.compute() }).executeSynchronously()
-            }
         }
 
         /**

--- a/src/main/java/org/sonarlint/intellij/SonarLintIntelliJClient.kt
+++ b/src/main/java/org/sonarlint/intellij/SonarLintIntelliJClient.kt
@@ -872,24 +872,17 @@ object SonarLintIntelliJClient : SonarLintRpcClientDelegate {
         }?.toSet() ?: return emptySet()
     }
 
+    @JvmOverloads
     fun toClientFileDto(
         project: Project,
         configScopeId: String,
         file: VirtualFile,
         relativePath: String,
         language: Language?,
+        includeFileContent: Boolean = false,
     ): ClientFileDto? {
         if (!file.isValid || FileUtilRt.isTooLarge(file.length)) return null
         val uri = VirtualFileUtils.toURI(file) ?: return null
-        var fileContent: String? = null
-        if (file.name == SONAR_SCANNER_CONFIG_FILENAME
-            || file.name == AUTOSCAN_CONFIG_FILENAME
-            || file.parent?.name == SONARLINT_CONFIGURATION_FOLDER
-            // Notebooks require special parsing, we should always send the content
-            || file.extension == "ipynb"
-        ) {
-            fileContent = computeReadActionSafely(project) { getFileContent(file) }
-        }
         return try {
             computeReadActionSafely(file, project) {
                 ClientFileDto(
@@ -899,7 +892,7 @@ object SonarLintIntelliJClient : SonarLintRpcClientDelegate {
                     isTestSources(file, project),
                     VirtualFileUtils.getEncoding(file, project),
                     Paths.get(file.path),
-                    fileContent,
+                    readFileContentIfNeeded(file, includeFileContent),
                     language,
                     true
                 )
@@ -908,6 +901,17 @@ object SonarLintIntelliJClient : SonarLintRpcClientDelegate {
             SonarLintConsole.get(project).error("Error while computing ClientFileDto", e)
             null
         }
+    }
+
+    private fun readFileContentIfNeeded(file: VirtualFile, includeFileContent: Boolean): String? {
+        val shouldReadContent = includeFileContent
+            || file.name == SONAR_SCANNER_CONFIG_FILENAME
+            || file.name == AUTOSCAN_CONFIG_FILENAME
+            || file.parent?.name == SONARLINT_CONFIGURATION_FOLDER
+            // Notebooks require special parsing, we should always send the content
+            || file.extension == "ipynb"
+        if (!shouldReadContent || FileUtilRt.isTooLarge(file.length)) return null
+        return getFileContent(file)
     }
 
     override fun didChangeTaintVulnerabilities(

--- a/src/main/java/org/sonarlint/intellij/core/BackendService.kt
+++ b/src/main/java/org/sonarlint/intellij/core/BackendService.kt
@@ -34,8 +34,6 @@ import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.project.ProjectManagerListener
-import com.intellij.openapi.roots.TestSourcesFilter.isTestSources
-import com.intellij.openapi.util.io.FileUtilRt
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.serviceContainer.NonInjectable
 import com.intellij.ui.jcef.JBCefApp
@@ -84,8 +82,6 @@ import org.sonarlint.intellij.promotion.UtmParameters
 import org.sonarlint.intellij.ui.UiUtils.Companion.runOnUiThread
 import org.sonarlint.intellij.util.GlobalLogOutput
 import org.sonarlint.intellij.util.SonarLintAppUtils.getRelativePathForAnalysis
-import org.sonarlint.intellij.util.VirtualFileUtils
-import org.sonarlint.intellij.util.VirtualFileUtils.getFileContent
 import org.sonarlint.intellij.util.VirtualFileUtils.toURI
 import org.sonarlint.intellij.util.runOnPooledThread
 import org.sonarsource.sonarlint.core.client.utils.ClientLogOutput
@@ -1075,32 +1071,21 @@ class BackendService : Disposable {
         events: List<VirtualFileEvent>,
         shouldIncludeContent: Boolean,
     ): List<ClientFileDto> {
-        val virtualFiles = events.filter { it.type == type }.map { it.virtualFile }.toList()
+        val filesOfType = events.filter { it.type == type }
+        val virtualFiles = filesOfType.map { it.virtualFile }.toList()
         val contributedLanguages = collectContributedLanguages(module, virtualFiles)
-        return events.filter { it.type == type }.mapNotNull {
+        val moduleId = moduleId(module)
+        return filesOfType.mapNotNull {
             val relativePath = getRelativePathForAnalysis(module, it.virtualFile) ?: return@mapNotNull null
-            val moduleId = moduleId(module)
             val forcedLanguage = contributedLanguages[it.virtualFile]?.let { fl -> Language.valueOf(fl.name) }
-            toURI(it.virtualFile)?.let { uri ->
-                computeReadActionSafely(it.virtualFile, module.project) {
-                    ClientFileDto(
-                        uri,
-                        Paths.get(relativePath),
-                        moduleId,
-                        isTestSources(it.virtualFile, module.project),
-                        VirtualFileUtils.getEncoding(it.virtualFile, module.project),
-                        Paths.get(it.virtualFile.path),
-                        // Notebooks require special parsing, we should always send the content
-                        if ((shouldIncludeContent || "ipynb" == it.virtualFile.extension)
-                            && !FileUtilRt.isTooLarge(it.virtualFile.length)
-                        ) getFileContent(it.virtualFile) else {
-                            null
-                        },
-                        forcedLanguage,
-                        true
-                    )
-                }
-            }
+            SonarLintIntelliJClient.toClientFileDto(
+                module.project,
+                moduleId,
+                it.virtualFile,
+                relativePath,
+                forcedLanguage,
+                shouldIncludeContent,
+            )
         }
     }
 

--- a/src/test/java/org/sonarlint/intellij/common/ui/ReadActionUtilsTests.kt
+++ b/src/test/java/org/sonarlint/intellij/common/ui/ReadActionUtilsTests.kt
@@ -85,6 +85,19 @@ class ReadActionUtilsTests : AbstractSonarLintLightTests() {
     }
 
     @Test
+    fun computeReadActionSafely_returns_null_when_virtual_file_expires_during_background_read() {
+        val expiringFile = mock(VirtualFile::class.java)
+        val validityChecks = AtomicInteger(0)
+        `when`(expiringFile.isValid).thenAnswer { validityChecks.incrementAndGet() > 1 }
+
+        val result = CompletableFuture.supplyAsync {
+            ReadActionUtils.computeReadActionSafely(expiringFile, project) { "ignored" }
+        }.get(10, TimeUnit.SECONDS)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
     fun computeReadActionSafely_returns_null_when_project_is_disposed() {
         val disposedProject = mock(Project::class.java)
         `when`(disposedProject.isDisposed).thenReturn(true)

--- a/src/test/java/org/sonarlint/intellij/common/ui/ReadActionUtilsTests.kt
+++ b/src/test/java/org/sonarlint/intellij/common/ui/ReadActionUtilsTests.kt
@@ -1,0 +1,112 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) SonarSource Sàrl
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.common.ui
+
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.sonarlint.intellij.AbstractSonarLintLightTests
+import org.sonarlint.intellij.ui.UiUtils.Companion.runOnUiThreadAndWait
+
+class ReadActionUtilsTests : AbstractSonarLintLightTests() {
+
+    @Test
+    fun computeReadActionSafely_returns_value_from_background_thread() {
+        val result = CompletableFuture.supplyAsync {
+            ReadActionUtils.computeReadActionSafely(project) { "computed" }
+        }.get(10, TimeUnit.SECONDS)
+
+        assertThat(result).isEqualTo("computed")
+    }
+
+    @Test
+    fun computeReadActionSafely_returns_null_when_project_is_disposed() {
+        val disposedProject = mock(Project::class.java)
+        `when`(disposedProject.isDisposed).thenReturn(true)
+
+        assertThat(ReadActionUtils.computeReadActionSafely(disposedProject) { "ignored" }).isNull()
+    }
+
+    @Test
+    fun runReadActionSafely_executes_from_background_thread() {
+        val executed = AtomicBoolean(false)
+
+        CompletableFuture.runAsync {
+            ReadActionUtils.runReadActionSafely(project) { executed.set(true) }
+        }.get(10, TimeUnit.SECONDS)
+
+        assertThat(executed).isTrue()
+    }
+
+    @Test
+    fun computeReadActionSafely_skips_invalid_virtual_file() {
+        val file = mock(VirtualFile::class.java)
+        `when`(file.isValid).thenReturn(false)
+
+        assertThat(ReadActionUtils.computeReadActionSafely(file, project) { "ignored" }).isNull()
+    }
+
+    @Test
+    fun computeReadActionSafelyInSmartMode_returns_value_for_valid_file() {
+        myFixture.configureByText("Sample.java", "class Sample {}")
+
+        val result = ReadActionUtils.computeReadActionSafelyInSmartMode(myFixture.file.virtualFile, project) {
+            myFixture.file.virtualFile.name
+        }
+
+        assertThat(result).isEqualTo("Sample.java")
+    }
+
+    @Test
+    fun computeReadActionSafely_returns_value_on_edt() {
+        runOnUiThreadAndWait(project, ModalityState.defaultModalityState()) {
+            assertThat(ReadActionUtils.computeReadActionSafely(project) { "computed-on-edt" })
+                .isEqualTo("computed-on-edt")
+        }
+    }
+
+    @Test
+    fun runReadActionSafely_executes_on_edt() {
+        val executed = AtomicBoolean(false)
+
+        runOnUiThreadAndWait(project, ModalityState.defaultModalityState()) {
+            ReadActionUtils.runReadActionSafely(project) { executed.set(true) }
+        }
+
+        assertThat(executed).isTrue()
+    }
+
+    @Test
+    fun computeReadActionSafelyInSmartMode_returns_null_when_project_is_disposed() {
+        myFixture.configureByText("Sample.java", "class Sample {}")
+        val file = myFixture.file.virtualFile
+        val disposedProject = mock(Project::class.java)
+        `when`(disposedProject.isDisposed).thenReturn(true)
+
+        assertThat(ReadActionUtils.computeReadActionSafelyInSmartMode(file, disposedProject) { file.name }).isNull()
+    }
+}

--- a/src/test/java/org/sonarlint/intellij/common/ui/ReadActionUtilsTests.kt
+++ b/src/test/java/org/sonarlint/intellij/common/ui/ReadActionUtilsTests.kt
@@ -25,6 +25,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -41,6 +42,46 @@ class ReadActionUtilsTests : AbstractSonarLintLightTests() {
         }.get(10, TimeUnit.SECONDS)
 
         assertThat(result).isEqualTo("computed")
+    }
+
+    @Test
+    fun computeReadActionSafely_returns_null_when_project_expires_during_background_read() {
+        val expiringProject = mock(Project::class.java)
+        val disposeChecks = AtomicInteger(0)
+        `when`(expiringProject.isDisposed).thenAnswer { disposeChecks.incrementAndGet() > 1 }
+
+        val result = CompletableFuture.supplyAsync {
+            ReadActionUtils.computeReadActionSafely(expiringProject) { "ignored" }
+        }.get(10, TimeUnit.SECONDS)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun runReadActionSafely_does_not_throw_when_project_expires_during_background_read() {
+        val expiringProject = mock(Project::class.java)
+        val disposeChecks = AtomicInteger(0)
+        `when`(expiringProject.isDisposed).thenAnswer { disposeChecks.incrementAndGet() > 1 }
+        val executed = AtomicBoolean(false)
+
+        CompletableFuture.runAsync {
+            ReadActionUtils.runReadActionSafely(expiringProject) { executed.set(true) }
+        }.get(10, TimeUnit.SECONDS)
+
+        assertThat(executed).isFalse()
+    }
+
+    @Test
+    fun computeReadActionSafelyInSmartMode_returns_value_from_background_thread() {
+        myFixture.configureByText("Sample.java", "class Sample {}")
+
+        val result = CompletableFuture.supplyAsync {
+            ReadActionUtils.computeReadActionSafelyInSmartMode(myFixture.file.virtualFile, project) {
+                myFixture.file.virtualFile.name
+            }
+        }.get(10, TimeUnit.SECONDS)
+
+        assertThat(result).isEqualTo("Sample.java")
     }
 
     @Test


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored read action infrastructure:**
  - Introduced `ReadActionUtils` helpers to use `ReadAction.nonBlocking` for background threads, ensuring long-running read actions are cancellable.
  - Implemented thread-aware dispatch to keep `ReadAction.compute` on the EDT while offloading background tasks.
- **Optimized file content processing:**
  - Decoupled `ClientFileDto` construction from file content reading in `SonarLintIntelliJClient` to improve efficiency.
  - Added `readFileContentIfNeeded` to centralize content access logic based on file type and size constraints.
- **Added comprehensive test suite:**
  - Introduced `ReadActionUtilsTests` to verify behavior across background threads and the EDT.

<sub>This will update automatically on new commits.</sub>