### PR TITLE
SLI-2724 Configure Renovate post-upgrade task to regenerate lock files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,24 @@
   ],
   "ignorePaths": [
     "its/projects/**"
+  ],
+  "packageRules": [
+    {
+      "description": "Regenerate Gradle lockfiles after dependency updates",
+      "matchManagers": [
+        "gradle",
+        "gradle-wrapper"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "./gradlew --write-locks dependencies :common:dependencies :clion:dependencies :clion-resharper:dependencies :nodejs:dependencies :git:dependencies :rider:dependencies :test-common:dependencies :its:dependencies"
+        ],
+        "fileFilters": [
+          "**/gradle.lockfile",
+          "**/settings-gradle.lockfile"
+        ],
+        "executionMode": "branch"
+      }
+    }
   ]
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Renovate configuration:**
  - Added `postUpgradeTasks` to regenerate Gradle lockfiles after dependency updates for `gradle` and `gradle-wrapper`.
  - Configured custom commands to write locks across all project modules using `./gradlew --write-locks`.

<sub>This will update automatically on new commits.</sub>