### PR TITLE
SLI-2748 Pull Gradle plugins from Artifactory

### DIFF
--- a/.github/scripts/download-ides.sh
+++ b/.github/scripts/download-ides.sh
@@ -10,7 +10,7 @@
 #
 # Environment variables (required):
 #   ARTIFACTORY_URL:          Repox/Artifactory base URL
-#   ARTIFACTORY_USER:         Authentication username
+#   ARTIFACTORY_USERNAME:     Authentication username
 #   ARTIFACTORY_ACCESS_TOKEN: Authentication token
 #
 # Exit codes:
@@ -36,7 +36,8 @@ fi
 IDE_TYPE="${BASH_REMATCH[1]}"
 IDE_VERSION="${BASH_REMATCH[2]}"
 
-: "${ARTIFACTORY_URL:?}" "${ARTIFACTORY_USER:?}" "${ARTIFACTORY_ACCESS_TOKEN:?}"
+ARTIFACTORY_URL="${ARTIFACTORY_URL%/}"
+: "${ARTIFACTORY_URL:?}" "${ARTIFACTORY_USERNAME:?}" "${ARTIFACTORY_ACCESS_TOKEN:?}"
 
 # Returns 0 (true) if the version is 2025.3 or later (unified distribution), 1 otherwise.
 # Unified distributions (2025.3+) no longer ship separate Community/Ultimate/Professional variants.
@@ -111,7 +112,7 @@ trap 'rm -rf "${TEMP_DIR}"' EXIT
 TEMP_FILE="${TEMP_DIR}/ide.tar.gz"
 
 echo "Downloading artifact..."
-if ! curl -fsSL -u "${ARTIFACTORY_USER}:${ARTIFACTORY_ACCESS_TOKEN}" -o "${TEMP_FILE}" "${DOWNLOAD_URL}"; then
+if ! curl -fsSL -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}" -o "${TEMP_FILE}" "${DOWNLOAD_URL}"; then
     echo "::error::Failed to download ${IDE_NAME} ${IDE_VERSION} from ${DOWNLOAD_URL}"
     exit 1
 fi

--- a/.github/scripts/setup-qa-ide.sh
+++ b/.github/scripts/setup-qa-ide.sh
@@ -9,7 +9,7 @@
 #
 # Environment variables (optional):
 #   ARTIFACTORY_URL:          Required for non-embedded IDEs (unless cached)
-#   ARTIFACTORY_USER:         Required for non-embedded IDEs (unless cached)
+#   ARTIFACTORY_USERNAME:     Authentication username
 #   ARTIFACTORY_ACCESS_TOKEN: Required for non-embedded IDEs (unless cached)
 #   GITHUB_ENV:               GitHub Actions environment file (for setting variables)
 #

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,20 +124,14 @@ jobs:
         with:
           version: 2025.9.12
 
-      - name: Fetch vault secrets
-        id: secrets
-        uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
+      - name: Configure Gradle
+        uses: SonarSource/ci-github-actions/config-gradle@71df716ff4caba2dbb7cd08a5f6fb932503602fc # 1.7.2
         with:
-          secrets: |
-            development/kv/data/repox url | ARTIFACTORY_URL;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username | ARTIFACTORY_USER;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
+          sonar-platform: none
+          artifactory-reader-role: private-reader
 
       - name: Run checks
         env:
-          ARTIFACTORY_URL: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_URL }}
-          ARTIFACTORY_ACCESS_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USER }}
-          ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
           IDEA_HOME: C:\Program Files\intellij
           RIDER_HOME: C:\Program Files\rider
           CLION_HOME: C:\Program Files\clion
@@ -371,6 +365,15 @@ jobs:
         with:
           version: 2025.9.12
 
+      - name: Configure Gradle
+        uses: SonarSource/ci-github-actions/config-gradle@71df716ff4caba2dbb7cd08a5f6fb932503602fc # 1.7.2
+        with:
+          sonar-platform: none
+          use-develocity: true
+          develocity-url: https://develocity.sonar.build
+          artifactory-reader-role: private-reader
+          disable-caching: 'true'
+
       - name: Select Java ${{ env.JDK_VERSION }}
         run: mise use java@${{ env.JDK_VERSION }}
 
@@ -379,9 +382,6 @@ jobs:
         uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
         with:
           secrets: |
-            development/kv/data/repox url | ARTIFACTORY_URL;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username | ARTIFACTORY_USER;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
             development/team/sonarlint/kv/data/ide.keys clion | CLION_KEY;
             development/team/sonarlint/kv/data/ide.keys goland | GOLAND_KEY;
             development/team/sonarlint/kv/data/ide.keys idea | IDEA_KEY;
@@ -390,7 +390,6 @@ jobs:
             development/team/sonarlint/kv/data/ide.keys rider | RIDER_KEY;
             development/github/token/licenses-ro token | GITHUB_TOKEN;
             development/team/sonarlint/kv/data/sonarcloud-it token | SONARCLOUD_IT_TOKEN;
-            development/kv/data/develocity token | DEVELOCITY_TOKEN;
 
       - name: Compute month key
         id: month
@@ -491,10 +490,6 @@ jobs:
             ${{ runner.os }}-jetbrains-ide-${{ matrix.ide_version }}-
 
       - name: Setup IDE for QA test
-        env:
-          ARTIFACTORY_URL: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_URL }}
-          ARTIFACTORY_USER: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USER }}
-          ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         run: .github/scripts/setup-qa-ide.sh "${{ matrix.ide_version }}"
 
       - name: Validate IDE setup for ${{ matrix.ide_version }}
@@ -533,9 +528,6 @@ jobs:
 
       - name: Extract and setup plugin
         env:
-          ARTIFACTORY_URL: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_URL }}
-          ARTIFACTORY_PRIVATE_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USER }}
-          ARTIFACTORY_PRIVATE_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
           PROJECT_VERSION: ${{ needs.build-plugin.outputs.PROJECT_VERSION }}
           CLION_KEY:    ${{ fromJSON(steps.secrets.outputs.vault).CLION_KEY }}
           GOLAND_KEY:   ${{ fromJSON(steps.secrets.outputs.vault).GOLAND_KEY }}
@@ -546,7 +538,7 @@ jobs:
         shell: bash --noprofile --norc -euo pipefail {0}
         run: |
           echo "Using project version: ${PROJECT_VERSION}"
-          curl -fsSL -u "${ARTIFACTORY_PRIVATE_USERNAME}:${ARTIFACTORY_PRIVATE_PASSWORD}" \
+          curl -fsSL -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}" \
             -o sonarlint-intellij.zip \
             "${ARTIFACTORY_URL}/sonarsource-public-qa/org/sonarsource/sonarlint/intellij/sonarlint-intellij/${PROJECT_VERSION}/sonarlint-intellij-${PROJECT_VERSION}.zip"
           unzip sonarlint-intellij.zip -d ${GITHUB_WORKSPACE}/downloaded-plugin
@@ -593,13 +585,9 @@ jobs:
           sleep 3
 
       - name: Start IDE in background
-        env:
-          ARTIFACTORY_URL: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_URL }}
-          ARTIFACTORY_ACCESS_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USER }}
-          ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         run: |
           # Start IDE in background using Gradle
-          nohup gradle :its:runIdeForUiTests --stacktrace -i \
+          nohup ./gradlew :its:runIdeForUiTests --stacktrace -i \
             -PijVersion=${IDEA_VERSION} \
             -PslPluginDirectory=${GITHUB_WORKSPACE}/downloaded-plugin > ${GITHUB_WORKSPACE}/runIdeGradle.log 2>&1 &
           echo "IDE_PID=$!" >> $GITHUB_ENV
@@ -625,15 +613,15 @@ jobs:
             -codec:v libx264 -r 12 ${GITHUB_WORKSPACE}/recording_${IDEA_VERSION}.mp4 &
           echo "FFMPEG_PID=$!" >> $GITHUB_ENV
 
+      - name: Configure Maven
+        uses: SonarSource/ci-github-actions/config-maven@71df716ff4caba2dbb7cd08a5f6fb932503602fc # 1.7.2
+        with:
+          artifactory-reader-role: private-reader
+
       - name: Run integration tests
         env:
-          ARTIFACTORY_URL: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_URL }}
-          ARTIFACTORY_ACCESS_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USER }}
-          ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
           SONARCLOUD_IT_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONARCLOUD_IT_TOKEN }}
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
-          DEVELOCITY_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN }}
-          DEVELOCITY_ACCESS_KEY: develocity.sonar.build=${{ fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN }}
         run: ./gradlew :its:check --stacktrace -i -PijVersion=${IDEA_VERSION} -PslPluginDirectory=${GITHUB_WORKSPACE}/downloaded-plugin --rerun-tasks
 
       - name: Stop recording

--- a/.github/workflows/plugin-verifier-nightly.yml
+++ b/.github/workflows/plugin-verifier-nightly.yml
@@ -47,23 +47,16 @@ jobs:
             gradle-${{ runner.os }}-nightly-
             gradle-${{ runner.os }}-
 
-      - name: Fetch vault secrets
-        id: secrets
-        uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
+      - name: Configure Gradle
+        uses: SonarSource/ci-github-actions/config-gradle@71df716ff4caba2dbb7cd08a5f6fb932503602fc # 1.7.2
         with:
-          secrets: |
-            development/kv/data/repox url | ARTIFACTORY_URL;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username | ARTIFACTORY_USER;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
-            development/kv/data/develocity token | DEVELOCITY_TOKEN;
+          sonar-platform: none
+          use-develocity: true
+          develocity-url: https://develocity.sonar.build
+          artifactory-reader-role: private-reader
+          disable-caching: 'true'
 
       - name: Run plugin verifier
-        env:
-          ARTIFACTORY_URL: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_URL }}
-          ARTIFACTORY_ACCESS_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USER }}
-          ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
-          DEVELOCITY_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN }}
-          DEVELOCITY_ACCESS_KEY: develocity.sonar.build=${{ fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN }}
         run: ./gradlew :verifyPlugin -PverifierEnv=LATEST
 
       - name: Upload reports on failure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,12 +13,12 @@ All dependency resolution goes through Artifactory. There is no Maven Central fa
 
 **Local development** — add to `~/.gradle/gradle.properties`:
 ```properties
-artifactoryUrl=https://repox.jfrog.io/repox
+artifactoryUrl=https://repox.jfrog.io/artifactory
 artifactoryUsername=<your-username>
 artifactoryPassword=<your-access-token>
 ```
 
-> CI uses environment variables instead (`ARTIFACTORY_URL`, `ARTIFACTORY_ACCESS_USERNAME`, `ARTIFACTORY_ACCESS_TOKEN`). Environment variables take priority over `gradle.properties` if both are set.
+> CI uses environment variables instead (`ARTIFACTORY_URL`, `ARTIFACTORY_USERNAME`, `ARTIFACTORY_ACCESS_TOKEN`). Environment variables take priority over `gradle.properties` if both are set.
 
 ## Architecture Overview
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,9 +35,6 @@ plugins {
 }
 
 buildscript {
-    repositories {
-        mavenCentral()
-    }
     dependencies {
         "classpath"("org.jetbrains.intellij:blockmap:1.0.10")
     }
@@ -51,13 +48,15 @@ val ideaHome: String? = System.getenv("IDEA_HOME")
 val runIdeDirectory: String by project
 val verifierEnv: String by project
 
-// The environment variables ARTIFACTORY_ACCESS_USERNAME and ARTIFACTORY_ACCESS_TOKEN are used on CI env
+// The environment variables ARTIFACTORY_USERNAME and ARTIFACTORY_ACCESS_TOKEN are used on CI
 // On local box, please add artifactoryUrl, artifactoryUsername and artifactoryPassword to ~/.gradle/gradle.properties
 val artifactoryUrl = System.getenv("ARTIFACTORY_URL")
 	?: (if (project.hasProperty("artifactoryUrl")) project.property("artifactoryUrl").toString() else "")
-val artifactoryUsername = System.getenv("ARTIFACTORY_ACCESS_USERNAME")
+val artifactoryUsername = System.getenv("ARTIFACTORY_USERNAME")
+    ?: System.getenv("ARTIFACTORY_ACCESS_USERNAME")
     ?: (if (project.hasProperty("artifactoryUsername")) project.property("artifactoryUsername").toString() else "")
 val artifactoryPassword = System.getenv("ARTIFACTORY_ACCESS_TOKEN")
+    ?: System.getenv("ARTIFACTORY_PASSWORD")
     ?: (if (project.hasProperty("artifactoryPassword")) project.property("artifactoryPassword").toString() else "")
 
 configurations {

--- a/its/projects/sample-sca/pom.xml
+++ b/its/projects/sample-sca/pom.xml
@@ -17,13 +17,6 @@
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>mavenCentral</id>
-            <url>https://repo1.maven.org/maven2/</url>
-        </repository>
-    </repositories>
-
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>
         <testSourceDirectory>src/test/kotlin</testSourceDirectory>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,28 @@ import java.net.URI
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.extensions.intellijPlatform
 
+pluginManagement {
+    // This block is compiled earlier than the rest of the script, so keep it self-contained.
+    val artifactoryUrl = (System.getenv("ARTIFACTORY_URL") ?: providers.gradleProperty("artifactoryUrl").orNull)
+        ?.removeSuffix("/")
+    val artifactoryUsername = System.getenv("ARTIFACTORY_USERNAME")
+        ?: System.getenv("ARTIFACTORY_ACCESS_USERNAME")
+        ?: providers.gradleProperty("artifactoryUsername").orNull
+    val artifactoryPassword = System.getenv("ARTIFACTORY_ACCESS_TOKEN")
+        ?: System.getenv("ARTIFACTORY_PASSWORD")
+        ?: providers.gradleProperty("artifactoryPassword").orNull
+    repositories {
+        maven {
+            if (artifactoryUrl != null && artifactoryUsername != null && artifactoryPassword != null) {
+                url = java.net.URI("$artifactoryUrl/plugins.gradle.org/")
+                credentials { username = artifactoryUsername; password = artifactoryPassword }
+            } else {
+                url = java.net.URI("https://plugins.gradle.org/m2/")
+            }
+        }
+    }
+}
+
 plugins {
     id("org.jetbrains.intellij.platform.settings") version "2.16.0"
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
@@ -10,9 +32,14 @@ plugins {
 }
 
 rootProject.name = "sonarlint-intellij"
-val artifactoryUrl = System.getenv("ARTIFACTORY_URL") ?: (extra.properties["artifactoryUrl"] as? String ?: "")
-val artifactoryUsername = System.getenv("ARTIFACTORY_ACCESS_USERNAME") ?: (extra.properties["artifactoryUsername"] as? String ?: "")
-val artifactoryPassword = System.getenv("ARTIFACTORY_ACCESS_TOKEN") ?: (extra.properties["artifactoryPassword"] as? String ?: "")
+val artifactoryUrl = ((System.getenv("ARTIFACTORY_URL") ?: extra.properties["artifactoryUrl"] as? String)
+    ?.removeSuffix("/")).orEmpty()
+val artifactoryUsername = (System.getenv("ARTIFACTORY_USERNAME")
+    ?: System.getenv("ARTIFACTORY_ACCESS_USERNAME")
+    ?: extra.properties["artifactoryUsername"] as? String).orEmpty()
+val artifactoryPassword = (System.getenv("ARTIFACTORY_ACCESS_TOKEN")
+    ?: System.getenv("ARTIFACTORY_PASSWORD")
+    ?: extra.properties["artifactoryPassword"] as? String).orEmpty()
 
 dependencyResolutionManagement {
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Build configuration:**
  - Refactored `pluginManagement` in `settings.gradle.kts` to resolve Gradle plugins from Artifactory using environment credentials.
  - Updated environment variable usage to standardize on `ARTIFACTORY_USERNAME` across build scripts and documentation.
- **CI/CD infrastructure:**
  - Replaced custom `vault-action-wrapper` secret fetching with `SonarSource/ci-github-actions/config-gradle` and `config-maven` for environment setup.
  - Updated `build.yml` and `plugin-verifier-nightly.yml` to utilize centralized build configuration actions.
- **Scripts and documentation:**
  - Updated `download-ides.sh` and `setup-qa-ide.sh` to align with the new environment variable naming convention.
  - Updated `AGENTS.md` to reflect updated Artifactory base URL and corrected environment variable requirements for local development.

<sub>This will update automatically on new commits.</sub>