### PR TITLE
SLI-2765 Pre-commit analysis should not block EDT

### DIFF
--- a/src/main/java/org/sonarlint/intellij/analysis/AnalysisSubmitter.kt
+++ b/src/main/java/org/sonarlint/intellij/analysis/AnalysisSubmitter.kt
@@ -49,7 +49,6 @@ import org.sonarlint.intellij.promotion.PromotionProvider
 import org.sonarlint.intellij.tasks.GlobalTaskProgressReporter
 import org.sonarlint.intellij.ui.ToolWindowConstants.TOOL_WINDOW_ID
 import org.sonarlint.intellij.util.SonarLintAppUtils.findModuleForFile
-import org.sonarlint.intellij.util.computeOnPooledThread
 import org.sonarlint.intellij.util.runOnPooledThread
 
 @Service(Service.Level.PROJECT)
@@ -110,7 +109,7 @@ class AnalysisSubmitter(private val project: Project) {
     fun analyzeFilesPreCommit(files: Set<VirtualFile>): Pair<CheckInCallable, List<UUID>>? {
         val callback = CheckInCallable()
         val analysisIds = mutableListOf<UUID>()
-        files.groupBy { file -> computeOnPooledThread(project, "Find Module For File") { findModuleForFile(file, project) } }
+        files.groupBy { file -> findModuleForFile(file, project) }
             .forEach { (module, moduleFiles) -> module?.let { awaitPreCommitAnalysisStart(it, moduleFiles, callback, analysisIds) } }
         return preCommitAnalysisResult(callback, analysisIds)
     }

--- a/src/main/java/org/sonarlint/intellij/trigger/SonarLintCheckinHandler.java
+++ b/src/main/java/org/sonarlint/intellij/trigger/SonarLintCheckinHandler.java
@@ -48,11 +48,11 @@ import javax.annotation.Nullable;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
-import org.apache.commons.lang3.tuple.Pair;
 import org.sonarlint.intellij.actions.SonarLintToolWindow;
 import org.sonarlint.intellij.analysis.AnalysisResult;
 import org.sonarlint.intellij.analysis.AnalysisSubmitter;
 import org.sonarlint.intellij.analysis.RunningAnalysesTracker;
+import org.sonarlint.intellij.callable.CheckInCallable;
 import org.sonarlint.intellij.cayc.CleanAsYouCodeService;
 import org.sonarlint.intellij.common.ui.SonarLintConsole;
 import org.sonarlint.intellij.common.util.SonarLintUtils;
@@ -108,7 +108,7 @@ public class SonarLintCheckinHandler extends CheckinHandler {
             return null;
           }
           var completed = waitForPreCommitAnalyses(indicator, analysisIdsByCallback.getRight());
-          return Pair.of(analysisIdsByCallback, completed);
+          return new PreCommitResult(analysisIdsByCallback.getLeft(), completed);
         });
 
       if (preCommitResult == null) {
@@ -116,15 +116,12 @@ public class SonarLintCheckinHandler extends CheckinHandler {
         return ReturnResult.COMMIT;
       }
 
-      var analysisIdsByCallback = preCommitResult.getLeft();
-      var completed = preCommitResult.getRight();
-
-      if (Boolean.FALSE.equals(completed) || !analysisIdsByCallback.getLeft().analysisSucceeded()) {
+      if (preCommitResult.failed()) {
         SonarLintConsole.get(project).debug("Pre-commit analysis failed");
         return showFailureMessage("Error analysing " + affectedFiles.size() + " changed file(s).");
       }
 
-      var results = analysisIdsByCallback.getLeft().getResults();
+      var results = preCommitResult.callback().getResults();
       return processResults(results);
     } catch (ProcessCanceledException e) {
       SonarLintConsole.get(project).debug("Pre-commit analysis cancelled by user");
@@ -284,6 +281,12 @@ public class SonarLintCheckinHandler extends CheckinHandler {
       getService(project, SonarLintToolWindow.class).openReportTab(analysisResult);
     } else {
       runOnUiThread(project, () -> getService(project, SonarLintToolWindow.class).openReportTab(analysisResult));
+    }
+  }
+
+  private record PreCommitResult(CheckInCallable callback, boolean completed) {
+    boolean failed() {
+      return !completed || !callback.analysisSucceeded();
     }
   }
 

--- a/src/main/java/org/sonarlint/intellij/trigger/SonarLintCheckinHandler.java
+++ b/src/main/java/org/sonarlint/intellij/trigger/SonarLintCheckinHandler.java
@@ -48,6 +48,7 @@ import javax.annotation.Nullable;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
+import org.apache.commons.lang3.tuple.Pair;
 import org.sonarlint.intellij.actions.SonarLintToolWindow;
 import org.sonarlint.intellij.analysis.AnalysisResult;
 import org.sonarlint.intellij.analysis.AnalysisSubmitter;
@@ -100,17 +101,23 @@ public class SonarLintCheckinHandler extends CheckinHandler {
     var affectedFiles = new HashSet<>(checkinPanel.getVirtualFiles());
 
     try {
-      var analysisIdsByCallback = getService(project, AnalysisSubmitter.class).analyzeFilesPreCommit(affectedFiles);
+      var preCommitResult = runModalTaskWithResult(project, "SonarQube for IDE Pre-Commit Analysis",
+        indicator -> {
+          var analysisIdsByCallback = getService(project, AnalysisSubmitter.class).analyzeFilesPreCommit(affectedFiles);
+          if (analysisIdsByCallback == null) {
+            return null;
+          }
+          var completed = waitForPreCommitAnalyses(indicator, analysisIdsByCallback.getRight());
+          return Pair.of(analysisIdsByCallback, completed);
+        });
 
-      if (analysisIdsByCallback == null) {
+      if (preCommitResult == null) {
         SonarLintConsole.get(project).debug("Pre-commit analysis cancelled because analysis did not start");
         return ReturnResult.COMMIT;
       }
 
-      var analysisIds = analysisIdsByCallback.getRight();
-
-      var completed = runModalTaskWithResult(project, "Waiting for SonarQube for IDE Analysis",
-        indicator -> waitForPreCommitAnalyses(indicator, analysisIds));
+      var analysisIdsByCallback = preCommitResult.getLeft();
+      var completed = preCommitResult.getRight();
 
       if (Boolean.FALSE.equals(completed) || !analysisIdsByCallback.getLeft().analysisSucceeded()) {
         SonarLintConsole.get(project).debug("Pre-commit analysis failed");
@@ -254,13 +261,11 @@ public class SonarLintCheckinHandler extends CheckinHandler {
       "Cancel",
       UIUtil.getWarningIcon());
 
-    if (answer == Messages.YES) {
-      return ReturnResult.CLOSE_WINDOW;
-    } else if (answer == Messages.CANCEL) {
-      return ReturnResult.CANCEL;
-    } else {
-      return ReturnResult.COMMIT;
-    }
+    return switch (answer) {
+      case Messages.YES -> ReturnResult.CLOSE_WINDOW;
+      case Messages.CANCEL -> ReturnResult.CANCEL;
+      default -> ReturnResult.COMMIT;
+    };
   }
 
   private ReturnResult showFailureMessage(String msg) {
@@ -271,13 +276,7 @@ public class SonarLintCheckinHandler extends CheckinHandler {
       "Abort",
       UIUtil.getErrorIcon());
 
-    if (answer == Messages.OK) {
-      return ReturnResult.COMMIT;
-    } else if (answer == Messages.CANCEL) {
-      return ReturnResult.CANCEL;
-    } else {
-      return ReturnResult.COMMIT;
-    }
+    return answer == Messages.CANCEL ? ReturnResult.CANCEL : ReturnResult.COMMIT;
   }
 
   private void showChangedFilesTab(AnalysisResult analysisResult) {


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored pre-commit analysis:**
  - Wrapped `analyzeFilesPreCommit` in a modal task to ensure non-blocking execution on the EDT.
  - Refactored `SonarLintCheckinHandler` to handle analysis results asynchronously using `runModalTaskWithResult`.
- **Code cleanup:**
  - Simplified `SonarLintCheckinHandler` logic using `switch` expressions and ternary operators.
  - Removed unnecessary `computeOnPooledThread` call in `AnalysisSubmitter` for file module resolution.

<sub>This will update automatically on new commits.</sub>