### PR TITLE
SLI-2794 Revert to updating rules on backend.

### DIFF
--- a/its/src/test/kotlin/org/sonarlint/intellij/its/tests/StandaloneIdeaTests.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/tests/StandaloneIdeaTests.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIf
 import org.sonarlint.intellij.its.BaseUiTest
+import org.sonarlint.intellij.its.tests.domain.CurrentFileTabTests.Companion.analyzeCurrentFileFromToolWindow
 import org.sonarlint.intellij.its.tests.domain.CurrentFileTabTests.Companion.verifyCurrentFileTabContainsMessages
 import org.sonarlint.intellij.its.tests.domain.ReportTabTests.Companion.analyzeAndVerifyReportTabContainsMessages
 import org.sonarlint.intellij.its.tests.domain.WalkthroughTests.Companion.closeWalkthrough
@@ -55,6 +56,10 @@ class StandaloneIdeaTests : BaseUiTest() {
             "No older issues",
             "No older Security Hotspots"
         )
+        // FIXME workaround until SLCORE-2533 is fixed.
+        // Re-enabling a rule does not auto-refresh already-open files; the Current File tab reflects
+        // the change only after an explicit re-analysis triggered from the tool window.
+        analyzeCurrentFileFromToolWindow()
         verifyCurrentFileTabContainsMessages(
             "Found 1 new issue from last 30 days",
         )

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/tests/domain/CurrentFileTabTests.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/tests/domain/CurrentFileTabTests.kt
@@ -130,6 +130,20 @@ class CurrentFileTabTests {
             }
         }
 
+        fun analyzeCurrentFileFromToolWindow() {
+            with(remoteRobot) {
+                idea {
+                    toolWindow {
+                        tabTitleContains("Findings") { select() }
+                        content("CurrentFilePanel") {
+                            toolBarButton("Analyze Current File").click()
+                        }
+                    }
+                    waitBackgroundTasksFinished()
+                }
+            }
+        }
+
         fun clickCurrentFileIssue(issueMessage: String) {
             with(remoteRobot) {
                 idea {

--- a/src/main/java/org/sonarlint/intellij/config/global/rules/RuleConfigurationPanel.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/rules/RuleConfigurationPanel.java
@@ -128,7 +128,6 @@ public class RuleConfigurationPanel implements Disposable, ConfigurationPanel<So
   private final Map<String, RulesTreeNode.LanguageNode> languageNodesByName = new HashMap<>();
   private final RulesFilterModel filterModel = new RulesFilterModel(this::updateModel);
   private final AtomicBoolean isDirty = new AtomicBoolean(false);
-  private final Map<String, SonarLintGlobalSettings.Rule> dirtyRules = new HashMap<>();
   private final Project project = ProjectManager.getInstance().getDefaultProject();
   private RulesTreeTable table;
   private RuleDescriptionPanel ruleDescription;
@@ -247,19 +246,15 @@ public class RuleConfigurationPanel implements Disposable, ConfigurationPanel<So
             loadNonDefaultRuleParams(getGlobalSettings(), ruleDefinitionDto)))
           .collect(Collectors.toMap(RulesTreeNode.Rule::getKey, r -> r));
 
-      dirtyRules.clear();
-
-      for (var persisted : persistedRules.values()) {
-        final var possiblyModified = allRulesStateByKey.get(persisted.getKey());
-        if (!persisted.equals(possiblyModified)) {
-          var dirtyRule = new SonarLintGlobalSettings.Rule(possiblyModified.getKey(), possiblyModified.isActivated());
-          dirtyRule.setParams(possiblyModified.getCustomParams());
-          dirtyRules.put(possiblyModified.getKey(), dirtyRule);
+        for (var persisted : persistedRules.values()) {
+          final var possiblyModified = allRulesStateByKey.get(persisted.getKey());
+          if (!persisted.equals(possiblyModified)) {
+            this.isDirty.lazySet(true);
+            return;
+          }
         }
-      }
-
-      this.isDirty.lazySet(!dirtyRules.isEmpty());
-    }).exceptionally(error -> {
+        this.isDirty.lazySet(false);
+      }).exceptionally(error -> {
       SonarLintConsole.get(project).error("Could not recompute rules: " + error.getMessage());
       return null;
     }));
@@ -276,7 +271,7 @@ public class RuleConfigurationPanel implements Disposable, ConfigurationPanel<So
         return rule;
       }));
     settings.setRulesByKey(nonDefaultRulesConfigurationByKey);
-    runOnPooledThread(project, () -> getService(BackendService.class).updateStandaloneRulesConfiguration(dirtyRules));
+    runOnPooledThread(project, () -> getService(BackendService.class).updateStandaloneRulesConfiguration(nonDefaultRulesConfigurationByKey));
   }
 
   @Override


### PR DESCRIPTION
----
## Summary by Gitar

- **Rule configuration updates:**
    - Reverted to updating standalone rules configuration on the backend using `nonDefaultRulesConfigurationByKey` instead of `dirtyRules` in `RuleConfigurationPanel.java`.

<sub>This will update automatically on new commits.</sub>