### PR TITLE
SLI-2803 Remove the SQC region selection checkbox

### DIFF
--- a/its/src/test/kotlin/org/sonarlint/intellij/its/tests/ConfigurationTests.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/tests/ConfigurationTests.kt
@@ -45,6 +45,7 @@ import org.sonarlint.intellij.its.tests.domain.CurrentFileTabTests.Companion.ver
 import org.sonarlint.intellij.its.tests.domain.CurrentFileTabTests.Companion.verifyIssueStatusWasSuccessfullyChanged
 import org.sonarlint.intellij.its.tests.domain.SharedConfigurationTests.Companion.importConfiguration
 import org.sonarlint.intellij.its.tests.domain.SharedConfigurationTests.Companion.shareConfiguration
+import org.sonarlint.intellij.its.utils.ConnectionType
 import org.sonarlint.intellij.its.utils.OpeningUtils.closeProject
 import org.sonarlint.intellij.its.utils.OpeningUtils.openExistingProject
 import org.sonarlint.intellij.its.utils.OpeningUtils.openFile
@@ -208,7 +209,7 @@ class ConfigurationTests : BaseUiTest() {
                 "No findings to display",
                 "This file is not automatically analyzed",
             )
-            enableConnectedModeFromCurrentFilePanel(SCALA_PROJECT_KEY, false, "Orchestrator")
+            enableConnectedModeFromCurrentFilePanel(SCALA_PROJECT_KEY, false, "Orchestrator", ConnectionType.SQS)
         }
 
     }
@@ -237,7 +238,7 @@ class ConfigurationTests : BaseUiTest() {
             openExistingProject("shared-connected-mode")
             bindProjectAndModuleInFileSettings("shared-connected-mode-module", SHARED_CONNECTED_MODE_KEY, SHARED_CONNECTED_MODE_MODULE_KEY)
             shareConfiguration()
-            enableConnectedModeFromCurrentFilePanel(SHARED_CONNECTED_MODE_KEY, false, "Orchestrator")
+            enableConnectedModeFromCurrentFilePanel(SHARED_CONNECTED_MODE_KEY, false, "Orchestrator", ConnectionType.SQS)
             clearConnections()
             closeProject()
             openExistingProject("shared-connected-mode", copyProjectFiles = false)
@@ -268,7 +269,7 @@ class ConfigurationTests : BaseUiTest() {
         fun `should create new connection from tool window and autofill created connection`() = uiTest {
             addSonarCloudConnection(sonarCloudToken, "Initial connection")
             openExistingProject("sli-java-issues")
-            enableConnectedModeFromCurrentFilePanel(SONARCLOUD_ISSUE_PROJECT_KEY, true, "Initial connection")
+            enableConnectedModeFromCurrentFilePanel(SONARCLOUD_ISSUE_PROJECT_KEY, true, "Initial connection", ConnectionType.SQC_EU)
             bindProjectFromToolWindow(SONARCLOUD_ISSUE_PROJECT_KEY, "New Connection Name", sonarCloudToken, "Initial connection")
         }
     }
@@ -308,7 +309,7 @@ class ConfigurationTests : BaseUiTest() {
             addSonarCloudConnection(sonarCloudToken, "SonarCloud-IT")
 
             openExistingProject("sli-java-issues")
-            enableConnectedModeFromCurrentFilePanel(SONARCLOUD_ISSUE_PROJECT_KEY, true, "SonarCloud-IT")
+            enableConnectedModeFromCurrentFilePanel(SONARCLOUD_ISSUE_PROJECT_KEY, true, "SonarCloud-IT", ConnectionType.SQC_EU)
             openFile("src/main/java/foo/Foo.java", "Foo.java")
             verifyCurrentFileTabContainsMessages("Remove this empty class, write its code or make it an \"interface\".")
 
@@ -317,7 +318,7 @@ class ConfigurationTests : BaseUiTest() {
             confirm()
             verifyIssueStatusWasSuccessfullyChanged()
 
-            enableConnectedModeFromCurrentFilePanel(SONARCLOUD_ISSUE_PROJECT_KEY, false, "SonarCloud-IT")
+            enableConnectedModeFromCurrentFilePanel(SONARCLOUD_ISSUE_PROJECT_KEY, false, "SonarCloud-IT", ConnectionType.SQC_EU)
         }
 
     }

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/tests/ConnectedAnalysisTests.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/tests/ConnectedAnalysisTests.kt
@@ -36,6 +36,7 @@ import org.sonarlint.intellij.its.BaseUiTest
 import org.sonarlint.intellij.its.tests.domain.CurrentFileTabTests.Companion.enableConnectedModeFromCurrentFilePanel
 import org.sonarlint.intellij.its.tests.domain.CurrentFileTabTests.Companion.verifyCurrentFileTabContainsMessages
 import org.sonarlint.intellij.its.tests.domain.ReportTabTests.Companion.analyzeAndVerifyReportTabContainsMessages
+import org.sonarlint.intellij.its.utils.ConnectionType
 import org.sonarlint.intellij.its.utils.FiltersUtils.resetFocusOnNewCode
 import org.sonarlint.intellij.its.utils.FiltersUtils.setFocusOnNewCode
 import org.sonarlint.intellij.its.utils.OpeningUtils.openExistingProject
@@ -145,7 +146,7 @@ class ConnectedAnalysisTests : BaseUiTest() {
             openExistingProject("sample-java-taint-vulnerability")
 
             // Focus On New Code Test
-            enableConnectedModeFromCurrentFilePanel(TAINT_VULNERABILITY_PROJECT_KEY, true, "Orchestrator")
+            enableConnectedModeFromCurrentFilePanel(TAINT_VULNERABILITY_PROJECT_KEY, true, "Orchestrator", ConnectionType.SQS)
             openFile("src/main/java/foo/FileWithSink.java", "FileWithSink.java")
             setFocusOnNewCode()
             analyzeAndVerifyReportTabContainsMessages(
@@ -164,14 +165,14 @@ class ConnectedAnalysisTests : BaseUiTest() {
         fun should_analyze_swift() = uiTest {
             openExistingProject("sample-swift")
 
-            enableConnectedModeFromCurrentFilePanel(TAINT_VULNERABILITY_PROJECT_KEY, true, "Orchestrator")
+            enableConnectedModeFromCurrentFilePanel(TAINT_VULNERABILITY_PROJECT_KEY, true, "Orchestrator", ConnectionType.SQS)
 
             openFile("file.swift")
             verifyCurrentFileTabContainsMessages(
                 "Found 1 issue",
                 "Use \"try\" or \"try?\" here instead; \"try!\" disables error propagation."
             )
-            enableConnectedModeFromCurrentFilePanel(TAINT_VULNERABILITY_PROJECT_KEY, false, "Orchestrator")
+            enableConnectedModeFromCurrentFilePanel(TAINT_VULNERABILITY_PROJECT_KEY, false, "Orchestrator", ConnectionType.SQS)
         }
 
     }

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/tests/OpenInIdeTests.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/tests/OpenInIdeTests.kt
@@ -53,6 +53,7 @@ import org.sonarlint.intellij.its.tests.domain.SecurityHotspotTabTests.Companion
 import org.sonarlint.intellij.its.tests.domain.SecurityHotspotTabTests.Companion.verifySecurityHotspotStatusWasSuccessfullyChanged
 import org.sonarlint.intellij.its.tests.domain.SecurityHotspotTabTests.Companion.verifySecurityHotspotTabContainsMessages
 import org.sonarlint.intellij.its.tests.domain.SecurityHotspotTabTests.Companion.verifySecurityHotspotTreeContainsMessages
+import org.sonarlint.intellij.its.utils.ConnectionType
 import org.sonarlint.intellij.its.utils.FiltersUtils.showOpenIssues
 import org.sonarlint.intellij.its.utils.FiltersUtils.showResolvedIssues
 import org.sonarlint.intellij.its.utils.OpeningUtils.openExistingProject
@@ -185,16 +186,16 @@ class OpenInIdeTests : BaseUiTest() {
             verifyHotspotOpened()
 
             // Should Propose To Bind
-            enableConnectedModeFromSecurityHotspotPanel(SECURITY_HOTSPOT_PROJECT_KEY, false, "Orchestrator")
+            enableConnectedModeFromSecurityHotspotPanel(SECURITY_HOTSPOT_PROJECT_KEY, false, "Orchestrator", ConnectionType.SQS)
             verifySecurityHotspotTabContainsMessages("The project is not bound, please bind it to SonarQube 9.7+ or SonarCloud")
 
             // Review Security Hotspot Test
-            enableConnectedModeFromSecurityHotspotPanel(SECURITY_HOTSPOT_PROJECT_KEY, true, "Orchestrator")
+            enableConnectedModeFromSecurityHotspotPanel(SECURITY_HOTSPOT_PROJECT_KEY, true, "Orchestrator", ConnectionType.SQS)
             verifySecurityHotspotTreeContainsMessages("Make sure using this hardcoded IP address is safe here.")
             openSecurityHotspotReviewDialogFromList("Make sure using this hardcoded IP address is safe here.")
             changeSecurityHotspotStatusAndPressChange("Fixed")
             verifySecurityHotspotStatusWasSuccessfullyChanged()
-            enableConnectedModeFromSecurityHotspotPanel(SECURITY_HOTSPOT_PROJECT_KEY, false, "Orchestrator")
+            enableConnectedModeFromSecurityHotspotPanel(SECURITY_HOTSPOT_PROJECT_KEY, false, "Orchestrator", ConnectionType.SQS)
         }
 
     }
@@ -247,7 +248,7 @@ class OpenInIdeTests : BaseUiTest() {
             )
             acceptNewSCAutomatedConnection()
             verifyIssueOpened()
-            enableConnectedModeFromCurrentFilePanel(SONARCLOUD_ISSUE_PROJECT_KEY, false, "sonarlint-it")
+            enableConnectedModeFromCurrentFilePanel(SONARCLOUD_ISSUE_PROJECT_KEY, false, "sonarlint-it", ConnectionType.SQC_EU)
         }
 
         @Test
@@ -255,7 +256,7 @@ class OpenInIdeTests : BaseUiTest() {
             openExistingProject(ISSUE_PROJECT_KEY)
 
             // Issue Analysis Test
-            enableConnectedModeFromCurrentFilePanel(ISSUE_PROJECT_KEY, true, "Orchestrator")
+            enableConnectedModeFromCurrentFilePanel(ISSUE_PROJECT_KEY, true, "Orchestrator", ConnectionType.SQS)
             openFile("src/main/java/foo/Foo.java", "Foo.java")
             verifyCurrentFileTabContainsMessages("Remove this empty class, write its code or make it an \"interface\".")
 

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/tests/domain/CurrentFileTabTests.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/tests/domain/CurrentFileTabTests.kt
@@ -27,6 +27,7 @@ import org.sonarlint.intellij.its.fixtures.dialog
 import org.sonarlint.intellij.its.fixtures.idea
 import org.sonarlint.intellij.its.fixtures.notification
 import org.sonarlint.intellij.its.fixtures.tool.window.toolWindow
+import org.sonarlint.intellij.its.utils.ConnectionType
 import org.sonarlint.intellij.its.utils.ProjectBindingUtils.disableConnectedMode
 import org.sonarlint.intellij.its.utils.ProjectBindingUtils.enableConnectedMode
 import org.sonarlint.intellij.its.utils.SettingsUtils.optionalIdeaFrame
@@ -157,7 +158,7 @@ class CurrentFileTabTests {
             }
         }
 
-        fun enableConnectedModeFromCurrentFilePanel(projectKey: String?, enabled: Boolean, connectionName: String) {
+        fun enableConnectedModeFromCurrentFilePanel(projectKey: String?, enabled: Boolean, connectionName: String, connectionType: ConnectionType) {
             optionalIdeaFrame()?.apply {
                 toolWindow {
                     tabTitleContains("Findings") { select() }
@@ -166,7 +167,7 @@ class CurrentFileTabTests {
                     }
                 }
                 if (enabled) {
-                    projectKey?.let { enableConnectedMode(it, connectionName) }
+                    projectKey?.let { enableConnectedMode(it, connectionName, connectionType) }
                 } else {
                     disableConnectedMode()
                 }

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/tests/domain/SecurityHotspotTabTests.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/tests/domain/SecurityHotspotTabTests.kt
@@ -27,6 +27,7 @@ import org.sonarlint.intellij.its.fixtures.dialog
 import org.sonarlint.intellij.its.fixtures.idea
 import org.sonarlint.intellij.its.fixtures.notification
 import org.sonarlint.intellij.its.fixtures.tool.window.toolWindow
+import org.sonarlint.intellij.its.utils.ConnectionType
 import org.sonarlint.intellij.its.utils.ProjectBindingUtils.disableConnectedMode
 import org.sonarlint.intellij.its.utils.ProjectBindingUtils.enableConnectedMode
 
@@ -104,7 +105,7 @@ class SecurityHotspotTabTests {
             }
         }
 
-        fun enableConnectedModeFromSecurityHotspotPanel(projectKey: String, enabled: Boolean, connectionName: String) {
+        fun enableConnectedModeFromSecurityHotspotPanel(projectKey: String, enabled: Boolean, connectionName: String, connectionType: ConnectionType) {
             with(remoteRobot) {
                 idea {
                     toolWindow {
@@ -114,7 +115,7 @@ class SecurityHotspotTabTests {
                         }
                     }
                     if (enabled) {
-                        enableConnectedMode(projectKey, connectionName)
+                        enableConnectedMode(projectKey, connectionName, connectionType)
                     } else {
                         disableConnectedMode()
                     }

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/tests/flavor/IaCTests.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/tests/flavor/IaCTests.kt
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.condition.EnabledIf
 import org.sonarlint.intellij.its.BaseUiTest
 import org.sonarlint.intellij.its.tests.domain.CurrentFileTabTests.Companion.enableConnectedModeFromCurrentFilePanel
 import org.sonarlint.intellij.its.tests.domain.CurrentFileTabTests.Companion.verifyCurrentFileTabContainsMessages
+import org.sonarlint.intellij.its.utils.ConnectionType
 import org.sonarlint.intellij.its.utils.OpeningUtils.openExistingProject
 import org.sonarlint.intellij.its.utils.OpeningUtils.openFile
 import org.sonarlint.intellij.its.utils.OrchestratorUtils.defaultBuilderEnv
@@ -84,7 +85,7 @@ class IaCTests : BaseUiTest() {
         openFile(filePath)
         verifyCurrentFileTabContainsMessages("No findings to display")
 
-        enableConnectedModeFromCurrentFilePanel(projectKey, true, "Orchestrator")
+        enableConnectedModeFromCurrentFilePanel(projectKey, true, "Orchestrator", ConnectionType.SQS)
 
         verifyCurrentFileTabContainsMessages(*expectedMessages)
     }

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/tests/flavor/PLSLQTest.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/tests/flavor/PLSLQTest.kt
@@ -33,6 +33,7 @@ import org.sonarlint.intellij.its.fixtures.idea
 import org.sonarlint.intellij.its.fixtures.tool.window.toolWindow
 import org.sonarlint.intellij.its.tests.domain.CurrentFileTabTests.Companion.enableConnectedModeFromCurrentFilePanel
 import org.sonarlint.intellij.its.tests.domain.CurrentFileTabTests.Companion.verifyCurrentFileTabContainsMessages
+import org.sonarlint.intellij.its.utils.ConnectionType
 import org.sonarlint.intellij.its.utils.OpeningUtils.openExistingProject
 import org.sonarlint.intellij.its.utils.OpeningUtils.openFile
 import org.sonarlint.intellij.its.utils.OrchestratorUtils.defaultBuilderEnv
@@ -52,7 +53,7 @@ class PLSQLTest : BaseUiTest() {
         openFile("file.pkb")
         verifyCurrentFileTabContainsMessages("No findings to display")
 
-        enableConnectedModeFromCurrentFilePanel(PLSQL_PROJECT_KEY, true, "Orchestrator")
+        enableConnectedModeFromCurrentFilePanel(PLSQL_PROJECT_KEY, true, "Orchestrator", ConnectionType.SQS)
 
         idea {
             waitBackgroundTasksFinished()

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/utils/ProjectBindingUtils.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/utils/ProjectBindingUtils.kt
@@ -50,15 +50,17 @@ object ProjectBindingUtils {
         }
     }
 
-    fun enableConnectedMode(projectKey: String, connectionName: String) {
+    fun enableConnectedMode(projectKey: String, connectionName: String, connectionType: ConnectionType) {
         with(remoteRobot) {
             idea {
                 dialog("Project Settings") {
+                    val connectionLabelWithPrefix = connectionType.uiLabelPrefix + connectionName
                     checkBox("Bind project to SonarQube (Server, Cloud)").select()
                     comboBox("Connection:").click()
                     remoteRobot.find<ContainerFixture>(byXpath("//div[@class='CustomComboPopup']")).apply {
-                        waitFor(Duration.ofSeconds(5)) { hasText(connectionName) }
-                        findText(connectionName).click()
+                        // a prefix is added only if there are multiple SQC connection. Check both with and without label
+                        waitFor(Duration.ofSeconds(5)) { hasText(connectionLabelWithPrefix) || hasText(connectionName) }
+                        findText { it.text == connectionLabelWithPrefix || it.text == connectionName }.click()
                     }
                     jbTextField().text = projectKey
                     button("OK").click()
@@ -107,4 +109,8 @@ object ProjectBindingUtils {
         }
     }
 
+}
+
+enum class ConnectionType(val uiLabelPrefix: String) {
+    SQS(""), SQC_EU("[EU] "), SQC_US("[US] ")
 }

--- a/its/src/test/kotlin/org/sonarlint/intellij/its/utils/SettingsUtils.kt
+++ b/its/src/test/kotlin/org/sonarlint/intellij/its/utils/SettingsUtils.kt
@@ -113,7 +113,7 @@ object SettingsUtils {
             addConnectionButton().clickWhenEnabled()
             dialog("New Connection: Server Details") {
                 keyboard { enterText("Orchestrator") }
-                jRadioButtons()[1].select()
+                jRadioButtons()[3].select()
                 jbTextFields()[1].text = serverUrl
                 button("Next").click()
             }

--- a/src/main/java/org/sonarlint/intellij/config/global/AutomaticServerConnectionCreator.kt
+++ b/src/main/java/org/sonarlint/intellij/config/global/AutomaticServerConnectionCreator.kt
@@ -184,7 +184,7 @@ class AutomaticServerConnectionCreator(private val serverOrOrg: String, private 
         connectionNameLabel.text = "Connection Name"
         scURLLabel.text = "SonarQube Cloud URL"
 
-        if (!isSQ && Settings.getGlobalSettings().isRegionEnabled) {
+        if (!isSQ) {
             centerPanel.add(
                 scURLLabel, GridBagConstraints(
                     1, ++gridY, 1, 1, 1.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, JBUI.emptyInsets(), 0, 0

--- a/src/main/java/org/sonarlint/intellij/config/global/ServerConnectionMgmtPanel.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/ServerConnectionMgmtPanel.java
@@ -65,7 +65,6 @@ import org.sonarlint.intellij.messages.GlobalConfigurationListener;
 import org.sonarlint.intellij.ui.icons.SonarLintIcons;
 
 import static org.sonarlint.intellij.common.util.SonarLintUtils.getService;
-import static org.sonarlint.intellij.config.Settings.getGlobalSettings;
 import static org.sonarlint.intellij.config.Settings.getSettingsFor;
 import static org.sonarlint.intellij.telemetry.LinkTelemetry.CONNECTED_MODE_DOCS;
 
@@ -131,7 +130,7 @@ public class ServerConnectionMgmtPanel implements ConfigurationPanel<SonarLintGl
     connectionList.setCellRenderer(new ColoredListCellRenderer<>() {
       @Override
       protected void customizeCellRenderer(JList list, ServerConnection server, int index, boolean selected, boolean hasFocus) {
-        if (server.isSonarCloud() && hasMoreThanOneSCConnections() && getGlobalSettings().isRegionEnabled()) {
+        if (server.isSonarCloud() && hasMoreThanOneSCConnections()) {
           var serverRegion = server.getRegion() == null ? "EU" : server.getRegion();
           append("[" + serverRegion + "] " + server.getName(), SimpleTextAttributes.REGULAR_ATTRIBUTES);
         } else {

--- a/src/main/java/org/sonarlint/intellij/config/global/SonarLintGlobalOptionsPanel.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/SonarLintGlobalOptionsPanel.java
@@ -60,7 +60,6 @@ public class SonarLintGlobalOptionsPanel implements ConfigurationPanel<SonarLint
   private JPanel rootPane;
   private JBCheckBox autoTrigger;
   private JBCheckBox neverDownloadCFamily;
-  private JBCheckBox enableRegion;
   private JBTextField nodeJsPath;
   private JBLabel nodeJsVersion;
   private JBCheckBox focusOnNewCode;
@@ -137,11 +136,6 @@ public class SonarLintGlobalOptionsPanel implements ConfigurationPanel<SonarLint
     optionsPanel.add(nodeJsVersion, new GridBagConstraints(2, gridy++, 1, 1, 0.0, 0.0,
       WEST, GridBagConstraints.HORIZONTAL, JBUI.emptyInsets(), 0, 0));
 
-    enableRegion = new JBCheckBox("Show region selection for SonarQube Cloud");
-    enableRegion.setFocusable(false);
-    optionsPanel.add(enableRegion, new GridBagConstraints(0, gridy, 3, 1, 0.0, 0.0,
-      WEST, GridBagConstraints.HORIZONTAL, JBUI.emptyInsets(), 0, 0));
-
     return optionsPanel;
   }
 
@@ -153,8 +147,7 @@ public class SonarLintGlobalOptionsPanel implements ConfigurationPanel<SonarLint
   @Override
   public boolean isModified(SonarLintGlobalSettings model) {
     getComponent();
-    return model.isRegionEnabled() != enableRegion.isSelected()
-      || model.isAutoTrigger() != autoTrigger.isSelected()
+    return model.isAutoTrigger() != autoTrigger.isSelected()
       || model.isNeverDownloadCFamilyAnalyzer() != neverDownloadCFamily.isSelected()
       || !Objects.equals(model.getNodejsPath(), nodeJsPath.getText())
       || model.isFocusOnNewCode() != focusOnNewCode.isSelected();
@@ -165,7 +158,6 @@ public class SonarLintGlobalOptionsPanel implements ConfigurationPanel<SonarLint
     getComponent();
     autoTrigger.setSelected(model.isAutoTrigger());
     neverDownloadCFamily.setSelected(model.isNeverDownloadCFamilyAnalyzer());
-    enableRegion.setSelected(model.isRegionEnabled());
     nodeJsPath.setText(model.getNodejsPath());
     nodeJsPath.getEmptyText().clear();
     focusOnNewCode.setSelected(model.isFocusOnNewCode());
@@ -227,7 +219,6 @@ public class SonarLintGlobalOptionsPanel implements ConfigurationPanel<SonarLint
     getService(CleanAsYouCodeService.class).setFocusOnNewCode(focusOnNewCode.isSelected(), settings);
     settings.setAutoTrigger(autoTrigger.isSelected());
     settings.setNeverDownloadCFamilyAnalyzer(neverDownloadCFamily.isSelected());
-    settings.setRegionEnabled(enableRegion.isSelected());
     // Do not let the user save an invalid path, this way we fall back to the auto-detection
     if (isNodejsPathValid(nodeJsPath.getText())) {
       settings.setNodejsPath(nodeJsPath.getText());
@@ -239,4 +230,3 @@ public class SonarLintGlobalOptionsPanel implements ConfigurationPanel<SonarLint
     return Files.exists(forcedNodeJsPath) && !Files.isDirectory(forcedNodeJsPath);
   }
 }
-

--- a/src/main/java/org/sonarlint/intellij/config/global/SonarLintGlobalSettings.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/SonarLintGlobalSettings.java
@@ -49,7 +49,6 @@ public final class SonarLintGlobalSettings {
   private String defaultFindingsScope = "CURRENT_FILE";
 
   private boolean autoTrigger = true;
-  private boolean isRegionEnabled = false;
   private String nodejsPath = "";
 
   private List<ServerConnection> servers = new LinkedList<>();
@@ -73,7 +72,6 @@ public final class SonarLintGlobalSettings {
     this.defaultSortMode = original.defaultSortMode;
     this.defaultFindingsScope = original.defaultFindingsScope;
     this.autoTrigger = original.autoTrigger;
-    this.isRegionEnabled = original.isRegionEnabled;
     this.nodejsPath = original.nodejsPath;
     this.hasWalkthroughRunOnce = original.hasWalkthroughRunOnce;
     this.secretsNeverBeenAnalysed = original.secretsNeverBeenAnalysed;
@@ -191,14 +189,6 @@ public final class SonarLintGlobalSettings {
 
   public void setAutoTrigger(boolean autoTrigger) {
     this.autoTrigger = autoTrigger;
-  }
-
-  public boolean isRegionEnabled() {
-    return isRegionEnabled;
-  }
-
-  public void setRegionEnabled(boolean regionEnabled) {
-    this.isRegionEnabled = regionEnabled;
   }
 
   public String getNodejsPath() {

--- a/src/main/java/org/sonarlint/intellij/config/global/wizard/OrganizationStep.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/wizard/OrganizationStep.java
@@ -37,7 +37,6 @@ import javax.swing.JPanel;
 import javax.swing.ListSelectionModel;
 import org.jetbrains.annotations.NotNull;
 import javax.annotation.Nullable;
-import org.sonarlint.intellij.config.Settings;
 import org.sonarlint.intellij.tasks.GetOrganizationTask;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.org.OrganizationDto;
 
@@ -168,11 +167,7 @@ public class OrganizationStep extends AbstractWizardStepEx {
     list.setEnabled(true);
     list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
     list.setCellRenderer(new ListRenderer());
-    if (Settings.getGlobalSettings().isRegionEnabled()) {
-      list.setEmptyText("No organizations found, make sure your region is correct or check the logs");
-    } else {
-      list.setEmptyText("No organizations found");
-    }
+    list.setEmptyText("No organizations found, make sure your region is correct or check the logs");
     TreeUIHelper.getInstance().installListSpeedSearch(list, o -> o.getName() + " " + o.getKey());
     orgList = list;
   }

--- a/src/main/java/org/sonarlint/intellij/config/global/wizard/ServerStep.form
+++ b/src/main/java/org/sonarlint/intellij/config/global/wizard/ServerStep.form
@@ -171,7 +171,7 @@
                       <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
-                      <text value="US - sonarqube.us"/>
+                      <text value="US - sonarqube.us (invite-only)"/>
                     </properties>
                   </component>
                 </children>

--- a/src/main/java/org/sonarlint/intellij/config/global/wizard/ServerStep.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/wizard/ServerStep.java
@@ -52,7 +52,6 @@ import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 
 import static org.sonarlint.intellij.common.util.SonarLintUtils.SONARCLOUD_URL;
 import static org.sonarlint.intellij.common.util.SonarLintUtils.US_SONARCLOUD_URL;
-import static org.sonarlint.intellij.config.Settings.getGlobalSettings;
 import static org.sonarlint.intellij.telemetry.LinkTelemetry.SONARCLOUD_FREE_SIGNUP_PAGE;
 
 public class ServerStep extends AbstractWizardStepEx {
@@ -149,12 +148,6 @@ public class ServerStep extends AbstractWizardStepEx {
   }
 
   private void load(boolean editing) {
-    var isRegionEnabled = getGlobalSettings().isRegionEnabled();
-
-    sonarCloudUrl.setVisible(isRegionEnabled);
-    radioEU.setVisible(isRegionEnabled);
-    radioUS.setVisible(isRegionEnabled);
-
     var sqsIcon = SonarLintIcons.ICON_SONARQUBE_SERVER;
     var sqcIcon = SonarLintIcons.ICON_SONARQUBE_CLOUD;
 

--- a/src/main/java/org/sonarlint/intellij/config/project/SonarLintProjectBindPanel.java
+++ b/src/main/java/org/sonarlint/intellij/config/project/SonarLintProjectBindPanel.java
@@ -74,7 +74,6 @@ import static java.awt.GridBagConstraints.NONE;
 import static java.awt.GridBagConstraints.WEST;
 import static java.util.Optional.ofNullable;
 import static org.sonarlint.intellij.common.util.SonarLintUtils.getService;
-import static org.sonarlint.intellij.config.Settings.getGlobalSettings;
 import static org.sonarlint.intellij.util.ThreadUtilsKt.computeOnPooledThread;
 
 public class SonarLintProjectBindPanel {
@@ -413,7 +412,7 @@ public class SonarLintProjectBindPanel {
 
       var serverRegion = value.getRegion() == null ? "EU" : value.getRegion();
 
-      if (value.isSonarCloud() && hasMoreThanOneSCConnections() && getGlobalSettings().isRegionEnabled()) {
+      if (value.isSonarCloud() && hasMoreThanOneSCConnections()) {
         append("[" + serverRegion + "] " + value.getName(), attrs, true);
       } else {
         append(value.getName(), attrs, true);

--- a/src/main/java/org/sonarlint/intellij/sharing/AutomaticSharedConfigCreator.kt
+++ b/src/main/java/org/sonarlint/intellij/sharing/AutomaticSharedConfigCreator.kt
@@ -51,7 +51,6 @@ import javax.swing.event.DocumentListener
 import javax.swing.event.HyperlinkEvent
 import org.sonarlint.intellij.actions.OpenInBrowserAction
 import org.sonarlint.intellij.common.ui.SonarLintConsole
-import org.sonarlint.intellij.common.util.SonarLintUtils.US_SONARCLOUD_URL
 import org.sonarlint.intellij.common.util.SonarLintUtils.getService
 import org.sonarlint.intellij.config.Settings.getGlobalSettings
 import org.sonarlint.intellij.config.Settings.getSettingsFor
@@ -280,20 +279,18 @@ class AutomaticSharedConfigCreator(
                 )
             )
         } else {
-            if (getGlobalSettings().isRegionEnabled) {
-                val scURLField = JBTextField(US_SONARCLOUD_URL).apply {
-                    isEditable = false
-                }
-
-                centerPanel.add(
-                    scURLLabel,
-                    GridBagConstraints(1, ++gridY, 1, 1, 1.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, JBUI.emptyInsets(), 0, 0)
-                )
-                centerPanel.add(
-                    scURLField,
-                    GridBagConstraints(1, ++gridY, 1, 1, 1.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, JBUI.emptyInsets(), 0, 0)
-                )
+            val scURLField = JBTextField(RegionUtils.getUrlByRegion(region)).apply {
+                isEditable = false
             }
+
+            centerPanel.add(
+                scURLLabel,
+                GridBagConstraints(1, ++gridY, 1, 1, 1.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, JBUI.emptyInsets(), 0, 0)
+            )
+            centerPanel.add(
+                scURLField,
+                GridBagConstraints(1, ++gridY, 1, 1, 1.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, JBUI.emptyInsets(), 0, 0)
+            )
         }
 
         connectionNameLabel.text = "Connection name"

--- a/src/test/java/org/sonarlint/intellij/config/global/SonarLintGlobalSettingsTests.java
+++ b/src/test/java/org/sonarlint/intellij/config/global/SonarLintGlobalSettingsTests.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.entry;
 
 class SonarLintGlobalSettingsTests {
 
-  private static final int EXPECTED_NON_STATIC_FIELD_COUNT = 15;
+  private static final int EXPECTED_NON_STATIC_FIELD_COUNT = 14;
   private static final String RULE = "rule";
   private static final String RULE1 = "rule1";
   private static final String PARAM = "param";
@@ -154,7 +154,6 @@ class SonarLintGlobalSettingsTests {
     original.setFocusOnNewCode(true);
     original.setPromotionDisabled(true);
     original.setAutoTrigger(false);
-    original.setRegionEnabled(true);
     original.setNodejsPath("/usr/local/node");
     original.setHasWalkthroughRunOnce(true);
     original.setSecretsNeverBeenAnalysed(false);
@@ -170,7 +169,6 @@ class SonarLintGlobalSettingsTests {
     assertThat(copy.isFocusOnNewCode()).isEqualTo(original.isFocusOnNewCode());
     assertThat(copy.isPromotionDisabled()).isEqualTo(original.isPromotionDisabled());
     assertThat(copy.isAutoTrigger()).isEqualTo(original.isAutoTrigger());
-    assertThat(copy.isRegionEnabled()).isEqualTo(original.isRegionEnabled());
     assertThat(copy.getNodejsPath()).isEqualTo(original.getNodejsPath());
     assertThat(copy.hasWalkthroughRunOnce()).isEqualTo(original.hasWalkthroughRunOnce());
     assertThat(copy.isSecretsNeverBeenAnalysed()).isEqualTo(original.isSecretsNeverBeenAnalysed());

--- a/src/test/java/org/sonarlint/intellij/config/global/wizard/ConnectionWizardModelTests.java
+++ b/src/test/java/org/sonarlint/intellij/config/global/wizard/ConnectionWizardModelTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.sonarlint.intellij.config.global.credentials.CredentialsService;
 import org.sonarlint.intellij.config.global.ServerConnection;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
+import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TokenDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.UsernamePasswordDto;
 
@@ -82,6 +83,7 @@ class ConnectionWizardModelTests {
 
     var server = model.createConnection();
     assertThat(server.getHostUrl()).isEqualTo("https://sonarcloud.io");
+    assertThat(server.getRegion()).isEqualTo(SonarCloudRegion.EU.name());
     assertThat(server.getOrganizationKey()).isEqualTo("org");
   }
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Configuration:**
    - Removed the SonarQube Cloud region selection checkbox and associated settings from global options
    - Updated server connection management and project binding panels to always display regions for multiple connections

<sub>This will update automatically on new commits.</sub>