### PR TITLE
SLI-2806 Update GitHub actions to 1.8.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           echo "ULTIMATE_HOME=${IDEA_ULTIMATE_2024_DIR}" >> $GITHUB_ENV
 
       - name: Build Plugin
-        uses: SonarSource/ci-github-actions/build-gradle@657e44543f55422ffd28b91d62fe5386f07d6030 # 1.6.0
+        uses: SonarSource/ci-github-actions/build-gradle@1df8fda46f8e82cfdd17b6a8e16a199282988b4f # 1.8.8
         id: build_plugin
         with:
           sonar-platform: none
@@ -125,7 +125,7 @@ jobs:
           version: 2025.9.12
 
       - name: Configure Gradle
-        uses: SonarSource/ci-github-actions/config-gradle@71df716ff4caba2dbb7cd08a5f6fb932503602fc # 1.7.2
+        uses: SonarSource/ci-github-actions/config-gradle@1df8fda46f8e82cfdd17b6a8e16a199282988b4f # 1.8.8
         with:
           sonar-platform: none
           artifactory-reader-role: private-reader
@@ -193,7 +193,7 @@ jobs:
           echo "ULTIMATE_HOME=${IDEA_ULTIMATE_2024_DIR}" >> $GITHUB_ENV
 
       - name: Run Tests and Sonar Analysis
-        uses: SonarSource/ci-github-actions/build-gradle@657e44543f55422ffd28b91d62fe5386f07d6030 # 1.6.0
+        uses: SonarSource/ci-github-actions/build-gradle@1df8fda46f8e82cfdd17b6a8e16a199282988b4f # 1.8.8
         with:
           deploy: false
           use-develocity: true
@@ -265,7 +265,7 @@ jobs:
             verifier-ides-${{ runner.os }}-
 
       - name: Verify Plugin Compatibility
-        uses: SonarSource/ci-github-actions/build-gradle@657e44543f55422ffd28b91d62fe5386f07d6030 # 1.6.0
+        uses: SonarSource/ci-github-actions/build-gradle@1df8fda46f8e82cfdd17b6a8e16a199282988b4f # 1.8.8
         with:
           deploy: false
           sonar-platform: none
@@ -366,7 +366,7 @@ jobs:
           version: 2025.9.12
 
       - name: Configure Gradle
-        uses: SonarSource/ci-github-actions/config-gradle@71df716ff4caba2dbb7cd08a5f6fb932503602fc # 1.7.2
+        uses: SonarSource/ci-github-actions/config-gradle@1df8fda46f8e82cfdd17b6a8e16a199282988b4f # 1.8.8
         with:
           sonar-platform: none
           use-develocity: true

--- a/.github/workflows/plugin-verifier-nightly.yml
+++ b/.github/workflows/plugin-verifier-nightly.yml
@@ -48,7 +48,7 @@ jobs:
             gradle-${{ runner.os }}-
 
       - name: Configure Gradle
-        uses: SonarSource/ci-github-actions/config-gradle@71df716ff4caba2dbb7cd08a5f6fb932503602fc # 1.7.2
+        uses: SonarSource/ci-github-actions/config-gradle@1df8fda46f8e82cfdd17b6a8e16a199282988b4f # 1.8.8
         with:
           sonar-platform: none
           use-develocity: true

--- a/.github/workflows/shadow_scans.yml
+++ b/.github/workflows/shadow_scans.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           version: 2025.9.12
 
-      - uses: SonarSource/ci-github-actions/build-gradle@657e44543f55422ffd28b91d62fe5386f07d6030 # 1.6.0
+      - uses: SonarSource/ci-github-actions/build-gradle@1df8fda46f8e82cfdd17b6a8e16a199282988b4f # 1.8.8
         env:
           IDEA_HOME: ${{ env.IDEA_2024_DIR }}
           CLION_HOME: ${{ env.CLION_2024_DIR }}


### PR DESCRIPTION
----
## Summary by Gitar

- **CI workflow updates:**
    - Updated GitHub Actions to `1.8.8` in `.github/workflows/build.yml`, `.github/workflows/plugin-verifier-nightly.yml`, and `.github/workflows/shadow_scans.yml`

<sub>This will update automatically on new commits.</sub>