### PR TITLE
SLI-2809 Add Generate Fix Prompt button to Findings and Report tabs

### DIFF
--- a/src/main/java/org/sonarlint/intellij/actions/GenerateFixPromptAction.kt
+++ b/src/main/java/org/sonarlint/intellij/actions/GenerateFixPromptAction.kt
@@ -1,0 +1,97 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) SonarSource Sàrl
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.actions
+
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.wm.ToolWindowManager
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+import org.sonarlint.intellij.common.util.SonarLintUtils
+import org.sonarlint.intellij.notifications.SonarLintProjectNotifications
+import org.sonarlint.intellij.ui.ToolWindowConstants.TOOL_WINDOW_ID
+import org.sonarlint.intellij.ui.UiUtils.Companion.runOnUiThread
+import org.sonarlint.intellij.ui.currentfile.CurrentFilePanel
+import org.sonarlint.intellij.ui.filter.FilteredFindings
+import org.sonarlint.intellij.ui.icons.SonarLintIcons
+import org.sonarlint.intellij.ui.report.ReportPanel
+import org.sonarlint.intellij.util.FixPromptGenerator
+
+/**
+ * Generates a structured prompt describing all currently displayed findings and copies it to the clipboard.
+ * Works from both the Findings and Report tabs.
+ */
+class GenerateFixPromptAction : AnAction(
+    "Generate Fix Prompt",
+    "Generate a prompt to fix all displayed findings and copy it to the clipboard",
+    SonarLintIcons.SPARKLE_GUTTER_ICON
+), DumbAware {
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+
+        runOnUiThread(project) {
+            val findings = getFindingsFromSelectedTab(project) ?: return@runOnUiThread
+            if (findings.isEmpty()) {
+                return@runOnUiThread
+            }
+
+            val prompt = FixPromptGenerator.generate(findings)
+            if (prompt.isBlank()) {
+                return@runOnUiThread
+            }
+
+            Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(prompt), null)
+
+            val count = FixPromptGenerator.countFindings(findings)
+            SonarLintProjectNotifications.get(project).displaySuccessfulNotification(
+                "Fix prompt copied to clipboard ($count ${SonarLintUtils.pluralize("finding", count)})",
+                NotificationGroupManager.getInstance().getNotificationGroup("SonarQube for IDE")
+            )
+        }
+    }
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        if (project == null) {
+            e.presentation.isEnabled = false
+            return
+        }
+
+        val findings = getFindingsFromSelectedTab(project)
+        e.presentation.isEnabled = findings?.isNotEmpty() == true
+    }
+
+    private fun getFindingsFromSelectedTab(project: com.intellij.openapi.project.Project): FilteredFindings? {
+        val toolWindow = ToolWindowManager.getInstance(project).getToolWindow(TOOL_WINDOW_ID) ?: return null
+        val selectedContent = toolWindow.contentManager.selectedContent ?: return null
+
+        return when (val component = selectedContent.component) {
+            is CurrentFilePanel -> component.getFilteredFindings()
+            is ReportPanel -> component.getFilteredFindings()
+            else -> null
+        }
+    }
+}

--- a/src/main/java/org/sonarlint/intellij/ui/currentfile/CurrentFilePanel.kt
+++ b/src/main/java/org/sonarlint/intellij/ui/currentfile/CurrentFilePanel.kt
@@ -341,6 +341,7 @@ class CurrentFilePanel(project: Project) : CurrentFileFindingsPanel(project) {
             listOf(actions.analyzeCurrentFileAction(), actions.cancelAnalysis()),
             listOf(actions.analyzeChangedFiles(), actions.analyzeAllFiles()),
             listOf(actions.expandAllTreesAction(), actions.collapseAllTreesAction()),
+            listOf(actions.generateFixPromptAction()),
             listOf(actions.configure(), actions.clearIssues())
         ))
     }
@@ -787,6 +788,8 @@ class CurrentFilePanel(project: Project) : CurrentFileFindingsPanel(project) {
             }
         }
     }
+
+    fun getFilteredFindings(): FilteredFindings = filteredFindingsCache
     
     private fun expandTreeBasedOnScope(tree: Tree, treeType: TreeType, findingsScope: FindingsScope) {
         when (findingsScope) {

--- a/src/main/java/org/sonarlint/intellij/ui/report/ReportPanel.kt
+++ b/src/main/java/org/sonarlint/intellij/ui/report/ReportPanel.kt
@@ -251,6 +251,7 @@ class ReportPanel(private val project: Project) : SimpleToolWindowPanel(false, f
             listOf(ShowReportFiltersAction(this@ReportPanel)),
             listOf(sonarLintActions.analyzeChangedFiles(), sonarLintActions.analyzeAllFiles()),
             listOf(sonarLintActions.expandAllTreesAction(), sonarLintActions.collapseAllTreesAction()),
+            listOf(sonarLintActions.generateFixPromptAction()),
             listOf(sonarLintActions.configure())
         )
 
@@ -593,6 +594,8 @@ class ReportPanel(private val project: Project) : SimpleToolWindowPanel(false, f
     fun collapseAllTrees() {
         treeManager.collapseTrees()
     }
+
+    fun getFilteredFindings(): FilteredFindings = filteredFindingsCache
 
     override fun dispose() {
         loadingIcon?.dispose()

--- a/src/main/java/org/sonarlint/intellij/util/FixPromptGenerator.kt
+++ b/src/main/java/org/sonarlint/intellij/util/FixPromptGenerator.kt
@@ -1,0 +1,276 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) SonarSource Sàrl
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.util
+
+import com.intellij.openapi.editor.RangeMarker
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.VirtualFile
+import java.util.Comparator
+import kotlin.math.max
+import kotlin.math.min
+import org.sonarlint.intellij.common.ui.ReadActionUtils.Companion.runReadActionSafely
+import org.sonarlint.intellij.finding.LiveFinding
+import org.sonarlint.intellij.finding.Location
+import org.sonarlint.intellij.finding.issue.LiveIssue
+import org.sonarlint.intellij.finding.issue.vulnerabilities.LocalTaintVulnerability
+import org.sonarlint.intellij.finding.sca.LocalDependencyRisk
+import org.sonarlint.intellij.ui.filter.FilteredFindings
+
+/**
+ * Builds a structured text prompt describing SonarQube findings so users can paste it into an AI coding agent.
+ */
+object FixPromptGenerator {
+
+    private const val PROMPT_HEADER = """
+Please fix the following SonarQube findings in this project. For each finding, apply the appropriate fix while preserving existing behavior, tests, and coding conventions. Explain briefly what you changed for each item.
+
+"""
+
+    private const val PROMPT_FOOTER = """
+After applying the fixes, run the relevant tests and static analysis to confirm the findings are resolved.
+"""
+
+    fun generate(findings: FilteredFindings): String {
+        if (findings.isEmpty()) {
+            return ""
+        }
+
+        val sections = mutableListOf<String>()
+        sections.add(PROMPT_HEADER.trim())
+
+        var index = 1
+        findings.issues.sortedWith(liveFindingComparator).forEach { issue ->
+            sections.add(formatIssue(index++, issue))
+        }
+        findings.hotspots.sortedWith(liveFindingComparator).forEach { hotspot ->
+            sections.add(formatSecurityHotspot(index++, hotspot))
+        }
+        findings.taints.forEach { taint ->
+            sections.add(formatTaint(index++, taint))
+        }
+        findings.dependencyRisks.forEach { risk ->
+            sections.add(formatDependencyRisk(index++, risk))
+        }
+
+        sections.add(PROMPT_FOOTER.trim())
+        return sections.joinToString("\n\n")
+    }
+
+    fun countFindings(findings: FilteredFindings): Int =
+        findings.issues.size + findings.hotspots.size + findings.taints.size + findings.dependencyRisks.size
+
+    private val liveFindingComparator = Comparator<LiveFinding> { a, b ->
+        compareValuesBy(a, b, { it.file().path }, { lineNumber(it.file(), it.range) })
+    }
+
+    private fun formatIssue(index: Int, issue: LiveIssue): String = buildString {
+        appendLine("## Finding $index — Issue")
+        appendLine("- **File:** ${issue.file().path}")
+        appendLine("- **Location:** ${formatLocation(issue.file(), issue.range)}")
+        appendLine("- **Rule:** ${issue.ruleKey}${issue.type?.let { " ($it)" } ?: ""}")
+        appendLine("- **Severity:** ${formatLiveFindingSeverity(issue)}")
+        appendLine("- **Message:** ${issue.message}")
+        appendStatusLines(issue)
+        appendQuickFixes(issue)
+        appendFlows(issue.context().orElse(null)?.flows())
+        appendCodeContext(issue.file(), issue.range)
+    }.trimEnd()
+
+    private fun formatSecurityHotspot(index: Int, hotspot: LiveFinding): String = buildString {
+        appendLine("## Finding $index — Security Hotspot")
+        appendLine("- **File:** ${hotspot.file().path}")
+        appendLine("- **Location:** ${formatLocation(hotspot.file(), hotspot.range)}")
+        appendLine("- **Rule:** ${hotspot.ruleKey}")
+        appendLine("- **Severity:** ${formatLiveFindingSeverity(hotspot)}")
+        appendLine("- **Message:** ${hotspot.message}")
+        appendStatusLines(hotspot)
+        appendQuickFixes(hotspot)
+        appendFlows(hotspot.context().orElse(null)?.flows())
+        appendCodeContext(hotspot.file(), hotspot.range)
+    }.trimEnd()
+
+    private fun formatTaint(index: Int, taint: LocalTaintVulnerability): String = buildString {
+        appendLine("## Finding $index — Taint Vulnerability")
+        appendLine("- **File:** ${taint.file()?.path ?: "Unknown"}")
+        appendLine("- **Location:** ${formatLocation(taint.file(), taint.rangeMarker())}")
+        appendLine("- **Rule:** ${taint.ruleKey}")
+        appendLine("- **Severity:** ${formatTaintSeverity(taint)}")
+        appendLine("- **Message:** ${taint.message()}")
+        if (taint.isResolved()) {
+            appendLine("- **Status:** Resolved")
+        }
+        if (taint.isOnNewCode()) {
+            appendLine("- **On new code:** Yes")
+        }
+        appendFlows(taint.flows)
+        appendCodeContext(taint.file(), taint.rangeMarker())
+    }.trimEnd()
+
+    private fun formatDependencyRisk(index: Int, risk: LocalDependencyRisk): String = buildString {
+        appendLine("## Finding $index — Dependency Risk")
+        appendLine("- **Package:** ${risk.packageName} ${risk.packageVersion}")
+        appendLine("- **Rule:** ${risk.ruleKey}")
+        appendLine("- **Type:** ${risk.type}")
+        appendLine("- **Severity:** ${risk.severity}")
+        appendLine("- **Quality:** ${risk.quality}")
+        risk.vulnerabilityId?.let { appendLine("- **Vulnerability ID:** $it") }
+        risk.cvssScore?.let { appendLine("- **CVSS score:** $it") }
+        appendLine("- **Action:** Upgrade or replace the dependency to a safe version.")
+    }.trimEnd()
+
+    private fun StringBuilder.appendStatusLines(finding: LiveFinding) {
+        if (finding.isResolved()) {
+            appendLine("- **Status:** Resolved")
+        }
+        if (finding.isOnNewCode()) {
+            appendLine("- **On new code:** Yes")
+        }
+    }
+
+    private fun StringBuilder.appendQuickFixes(finding: LiveFinding) {
+        val quickFixes = finding.quickFixes()
+        if (quickFixes.isNotEmpty()) {
+            appendLine("- **Suggested quick fixes:**")
+            quickFixes.forEach { quickFix ->
+                appendLine("  - ${quickFix.message}")
+            }
+        }
+    }
+
+    private fun StringBuilder.appendFlows(flows: List<org.sonarlint.intellij.finding.Flow>?) {
+        if (flows.isNullOrEmpty()) {
+            return
+        }
+        appendLine("- **Data flows:**")
+        flows.forEachIndexed { flowIndex, flow ->
+            appendLine("  - Flow ${flowIndex + 1}:")
+            flow.locations.forEachIndexed { locationIndex, location ->
+                appendLine("    ${locationIndex + 1}. ${formatFlowLocation(location)}")
+            }
+        }
+    }
+
+    private fun StringBuilder.appendCodeContext(file: VirtualFile?, range: RangeMarker?) {
+        extractCodeContext(file, range)?.let { context ->
+            appendLine("- **Code context:**")
+            appendLine("```")
+            appendLine(context)
+            append("```")
+        }
+    }
+
+    private fun formatLiveFindingSeverity(finding: LiveFinding): String {
+        if (finding.isMqrMode) {
+            val attribute = finding.cleanCodeAttribute?.name?.replace('_', ' ')?.lowercase()?.replaceFirstChar { it.titlecase() }
+            val impacts = finding.impacts.joinToString(", ") { "${it.softwareQuality}: ${it.impactSeverity}" }
+            return buildString {
+                if (attribute != null) {
+                    append("Clean code attribute: $attribute")
+                }
+                if (impacts.isNotEmpty()) {
+                    if (isNotEmpty()) append("; ")
+                    append("Impacts: $impacts")
+                }
+                if (isEmpty()) append("Unknown")
+            }
+        }
+        return finding.userSeverity?.name ?: "Unknown"
+    }
+
+    private fun formatTaintSeverity(taint: LocalTaintVulnerability): String {
+        taint.severity()?.name?.let { return it }
+        val attribute = taint.cleanCodeAttribute?.name?.replace('_', ' ')?.lowercase()?.replaceFirstChar { it.titlecase() }
+        val impacts = taint.impacts.joinToString(", ") { "${it.softwareQuality}: ${it.impactSeverity}" }
+        return when {
+            attribute != null && impacts.isNotEmpty() -> "Clean code attribute: $attribute; Impacts: $impacts"
+            attribute != null -> "Clean code attribute: $attribute"
+            impacts.isNotEmpty() -> "Impacts: $impacts"
+            else -> "Unknown"
+        }
+    }
+
+    private fun formatLocation(file: VirtualFile?, range: RangeMarker?): String {
+        if (range == null) {
+            return "Unknown"
+        }
+        var result = "Unknown"
+        runReadActionSafely {
+            if (!range.isValid || file == null || !file.isValid) return@runReadActionSafely
+            val document = FileDocumentManager.getInstance().getCachedDocument(file) ?: return@runReadActionSafely
+            val line = document.getLineNumber(range.startOffset) + 1
+            val column = range.startOffset - document.getLineStartOffset(line - 1) + 1
+            val endLine = document.getLineNumber(range.endOffset) + 1
+            result = if (line == endLine) {
+                "line $line, column $column"
+            } else {
+                "lines $line-$endLine, column $column"
+            }
+        }
+        return result
+    }
+
+    private fun formatFlowLocation(location: Location): String {
+        val coords = formatLocation(location.file, location.range)
+        val message = location.message?.takeIf { it.isNotBlank() }
+        val filePath = location.file?.path ?: location.originalFileName ?: "Unknown file"
+        return if (message != null) {
+            "$filePath ($coords) — $message"
+        } else {
+            "$filePath ($coords)"
+        }
+    }
+
+    private fun lineNumber(file: VirtualFile?, range: RangeMarker?): Int {
+        if (range == null) {
+            return Int.MAX_VALUE
+        }
+        var result = Int.MAX_VALUE
+        runReadActionSafely {
+            if (!range.isValid || file == null || !file.isValid) return@runReadActionSafely
+            val document = FileDocumentManager.getInstance().getCachedDocument(file) ?: return@runReadActionSafely
+            result = document.getLineNumber(range.startOffset)
+        }
+        return result
+    }
+
+    internal fun extractCodeContext(file: VirtualFile?, range: RangeMarker?, contextLines: Int = 2): String? {
+        if (range == null) {
+            return null
+        }
+        var result: String? = null
+        runReadActionSafely {
+            if (!range.isValid || file == null || !file.isValid) return@runReadActionSafely
+            val document = FileDocumentManager.getInstance().getCachedDocument(file) ?: return@runReadActionSafely
+            val startLine = document.getLineNumber(range.startOffset)
+            val endLine = document.getLineNumber(range.endOffset)
+            val fromLine = max(0, startLine - contextLines)
+            val toLine = min(document.lineCount - 1, endLine + contextLines)
+            result = buildString {
+                for (line in fromLine..toLine) {
+                    val lineStart = document.getLineStartOffset(line)
+                    val lineEnd = document.getLineEndOffset(line)
+                    appendLine("${line + 1}: ${document.getText(TextRange(lineStart, lineEnd))}")
+                }
+            }.trimEnd()
+        }
+        return result
+    }
+}

--- a/src/main/java/org/sonarlint/intellij/util/SonarLintActions.java
+++ b/src/main/java/org/sonarlint/intellij/util/SonarLintActions.java
@@ -29,6 +29,7 @@ import org.sonarlint.intellij.ui.icons.SonarLintIcons;
 import org.sonarlint.intellij.actions.ClearCurrentFileIssuesAction;
 import org.sonarlint.intellij.actions.CollapseAllTreesAction;
 import org.sonarlint.intellij.actions.ExpandAllTreesAction;
+import org.sonarlint.intellij.actions.GenerateFixPromptAction;
 import org.sonarlint.intellij.actions.RestartBackendAction;
 import org.sonarlint.intellij.actions.SonarAnalyzeAllFilesAction;
 import org.sonarlint.intellij.actions.SonarAnalyzeChangedFilesAction;
@@ -57,6 +58,7 @@ public final class SonarLintActions {
   private final AnAction restartSonarLintAction;
   private final AnAction expandAllTreesAction;
   private final AnAction collapseAllTreesAction;
+  private final AnAction generateFixPromptAction;
 
   public SonarLintActions() {
     this(ActionManager.getInstance());
@@ -96,6 +98,7 @@ public final class SonarLintActions {
     restartSonarLintAction = new RestartBackendAction();
     expandAllTreesAction = new ExpandAllTreesAction();
     collapseAllTreesAction = new CollapseAllTreesAction();
+    generateFixPromptAction = new GenerateFixPromptAction();
   }
 
   public static SonarLintActions getInstance() {
@@ -144,6 +147,10 @@ public final class SonarLintActions {
 
   public AnAction collapseAllTreesAction() {
     return collapseAllTreesAction;
+  }
+
+  public AnAction generateFixPromptAction() {
+    return generateFixPromptAction;
   }
 
 }

--- a/src/test/java/org/sonarlint/intellij/actions/GenerateFixPromptActionTests.kt
+++ b/src/test/java/org/sonarlint/intellij/actions/GenerateFixPromptActionTests.kt
@@ -1,0 +1,53 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) SonarSource Sàrl
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.Presentation
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.sonarlint.intellij.AbstractSonarLintLightTests
+
+class GenerateFixPromptActionTests : AbstractSonarLintLightTests() {
+
+    private lateinit var action: GenerateFixPromptAction
+    private lateinit var mockEvent: AnActionEvent
+    private lateinit var presentation: Presentation
+
+    @BeforeEach
+    fun init() {
+        action = GenerateFixPromptAction()
+        presentation = Presentation()
+        mockEvent = mock(AnActionEvent::class.java)
+        `when`(mockEvent.presentation).thenReturn(presentation)
+    }
+
+    @Test
+    fun `update disables action when project is null`() {
+        `when`(mockEvent.project).thenReturn(null)
+
+        action.update(mockEvent)
+
+        assertThat(presentation.isEnabled).isFalse()
+    }
+}

--- a/src/test/java/org/sonarlint/intellij/util/FixPromptGeneratorTests.kt
+++ b/src/test/java/org/sonarlint/intellij/util/FixPromptGeneratorTests.kt
@@ -1,0 +1,111 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) SonarSource Sàrl
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ */
+package org.sonarlint.intellij.util
+
+import com.intellij.openapi.vfs.VirtualFile
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.sonarlint.intellij.finding.issue.LiveIssue
+import org.sonarlint.intellij.finding.sca.aDependencyRisk
+import org.sonarlint.intellij.ui.filter.FilteredFindings
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.DependencyRiskDto
+import org.sonarsource.sonarlint.core.rpc.protocol.client.issue.RaisedIssueDto
+import org.sonarsource.sonarlint.core.rpc.protocol.common.Either
+import org.sonarsource.sonarlint.core.rpc.protocol.common.IssueSeverity
+import org.sonarsource.sonarlint.core.rpc.protocol.common.RuleType
+import org.sonarsource.sonarlint.core.rpc.protocol.common.StandardModeDetails
+
+class FixPromptGeneratorTests {
+
+    @Test
+    fun `generate returns empty string when no findings`() {
+        assertThat(FixPromptGenerator.generate(FilteredFindings(emptyList(), emptyList(), emptyList(), emptyList()))).isEmpty()
+    }
+
+    @Test
+    fun `generate includes issue details`() {
+        val issue = anIssue(
+            path = "/project/src/Foo.java",
+            message = "Remove this unused variable",
+            ruleKey = "java:S1481",
+            severity = IssueSeverity.MINOR,
+            type = RuleType.CODE_SMELL
+        )
+
+        val prompt = FixPromptGenerator.generate(FilteredFindings(listOf(issue), emptyList(), emptyList(), emptyList()))
+
+        assertThat(prompt).contains("Please fix the following SonarQube findings")
+        assertThat(prompt).contains("## Finding 1 — Issue")
+        assertThat(prompt).contains("**File:** /project/src/Foo.java")
+        assertThat(prompt).contains("**Rule:** java:S1481 (CODE_SMELL)")
+        assertThat(prompt).contains("**Severity:** MINOR")
+        assertThat(prompt).contains("**Message:** Remove this unused variable")
+        assertThat(prompt).contains("run the relevant tests")
+    }
+
+    @Test
+    fun `generate includes dependency risk details`() {
+        val risk = aDependencyRisk(DependencyRiskDto.Status.OPEN)
+
+        val prompt = FixPromptGenerator.generate(FilteredFindings(emptyList(), emptyList(), emptyList(), listOf(risk)))
+
+        assertThat(prompt).contains("## Finding 1 — Dependency Risk")
+        assertThat(prompt).contains("**Package:** ${risk.packageName} ${risk.packageVersion}")
+        assertThat(prompt).contains("dependency-risk:")
+        assertThat(prompt).contains("Upgrade or replace the dependency")
+    }
+
+    @Test
+    fun `countFindings returns total number of displayed findings`() {
+        val issue = anIssue("/a.java", "msg", "java:S1", IssueSeverity.MAJOR, RuleType.BUG)
+        val findings = FilteredFindings(listOf(issue), emptyList(), emptyList(), listOf(aDependencyRisk(DependencyRiskDto.Status.OPEN)))
+
+        assertThat(FixPromptGenerator.countFindings(findings)).isEqualTo(2)
+    }
+
+    @Test
+    fun `generate sorts issues by file path`() {
+        val issueB = anIssue("/project/B.java", "Second", "java:S2", IssueSeverity.MAJOR, RuleType.BUG)
+        val issueA = anIssue("/project/A.java", "First", "java:S1", IssueSeverity.MAJOR, RuleType.BUG)
+
+        val prompt = FixPromptGenerator.generate(FilteredFindings(listOf(issueB, issueA), emptyList(), emptyList(), emptyList()))
+
+        assertThat(prompt.indexOf("A.java")).isLessThan(prompt.indexOf("B.java"))
+    }
+
+    private fun anIssue(
+        path: String,
+        message: String,
+        ruleKey: String,
+        severity: IssueSeverity,
+        type: RuleType,
+    ): LiveIssue {
+        val dto = Mockito.mock(RaisedIssueDto::class.java)
+        `when`(dto.primaryMessage).thenReturn(message)
+        `when`(dto.ruleKey).thenReturn(ruleKey)
+        `when`(dto.severityMode).thenReturn(Either.forLeft(StandardModeDetails(severity, type)))
+        val file = Mockito.mock(VirtualFile::class.java)
+        `when`(file.path).thenReturn(path)
+        `when`(file.isValid).thenReturn(true)
+        return LiveIssue(null, dto, file, emptyList())
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Generate Fix Prompt** toolbar button to both the **Findings** and **Report** tabs in the SonarQube for IDE tool window. When clicked, it builds a structured prompt from all currently displayed findings (respecting active filters) and copies it to the clipboard so users can paste it into their preferred AI coding agent.

## Motivation

Users increasingly rely on external AI agents to fix code issues. This feature makes it easy to export all relevant SonarQube context in one action, without manually copying findings one by one.

## Changes

- **`FixPromptGenerator`**: Builds a markdown-style prompt including:
  - File path and line/column location
  - Rule key, type, and severity (standard or MQR mode)
  - Finding message, status, and new-code flag
  - Suggested quick fixes (when available)
  - Data flow locations (when available)
  - Surrounding code context (±2 lines)
  - Dependency risk details for SCA findings
- **`GenerateFixPromptAction`**: Toolbar action registered in `SonarLintActions`, added to Findings and Report tab toolbars. Copies the prompt to the clipboard and shows a confirmation notification.
- **`getFilteredFindings()`** exposed on `CurrentFilePanel` and `ReportPanel` so the action uses the same filtered view the user sees.

## Testing

- `FixPromptGeneratorTests`: prompt content, sorting, empty findings, dependency risks
- `GenerateFixPromptActionTests`: action disabled when project is null

> **Note:** Full Gradle build could not be run in the cloud agent environment (Artifactory credentials required). Please run locally:
> ```bash
> ./gradlew -x :its:check test --tests org.sonarlint.intellij.util.FixPromptGeneratorTests --tests org.sonarlint.intellij.actions.GenerateFixPromptActionTests
> ```

## Checklist

- [x] Explain the change and the problem it solves
- [x] Provide unit tests for new code
- [ ] Verify formatting against SonarSource developer toolset
- [ ] Run full `./gradlew -x :its:check check` locally with Artifactory configured
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60240eeb-3584-4679-81ae-e05d6d082823?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60240eeb-3584-4679-81ae-e05d6d082823&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

