### PR TITLE
SLI-2811 Stop declaring deprecated CONTEXT_GENERATION backend capability

### DIFF
--- a/src/main/java/org/sonarlint/intellij/core/BackendService.kt
+++ b/src/main/java/org/sonarlint/intellij/core/BackendService.kt
@@ -398,7 +398,6 @@ class BackendService : Disposable {
             BackendCapability.SMART_NOTIFICATIONS,
             BackendCapability.ISSUE_STREAMING,
             BackendCapability.SCA_SYNCHRONIZATION,
-            BackendCapability.CONTEXT_GENERATION,
             BackendCapability.PROMOTIONAL_CAMPAIGNS
         )
         if (!System.getProperty("sonarlint.telemetry.disabled", "false").toBoolean()) {


### PR DESCRIPTION
## Summary
- Remove `BackendCapability.CONTEXT_GENERATION` from backend initialization capabilities.
- Follow-up to the SonarCodeContext removal / capability deprecation in sonarlint-core ([SLCORE-2540](https://sonarsource.atlassian.net/browse/SLCORE-2540)).

## Test plan
- [ ] Confirm plugin still initializes SLOOP successfully
- [ ] Smoke-check connected mode / analysis still works

[SLCORE-2540]: https://sonarsource.atlassian.net/browse/SLCORE-2540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ