### PR TITLE
SLI-2267 Upload released artifact to JetBrains marketplace

### DIFF
--- a/.github/actions/upload-to-jetbrains-marketplace/action.yml
+++ b/.github/actions/upload-to-jetbrains-marketplace/action.yml
@@ -22,7 +22,7 @@ runs:
       with:
         secrets: |
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-public-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
-          development/team/sonarlint/kv/data/jetbrains-marketplace token | JETBRAINS_MARKETPLACE_TOKEN;
+          development/team/sonarlint/kv/data/jetbrains-marketplace-token token | JETBRAINS_MARKETPLACE_TOKEN;
 
     - name: Download plugin from Artifactory
       shell: bash

--- a/.github/actions/upload-to-jetbrains-marketplace/action.yml
+++ b/.github/actions/upload-to-jetbrains-marketplace/action.yml
@@ -22,7 +22,7 @@ runs:
       with:
         secrets: |
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-public-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
-          development/team/sonarlint/kv/data/jetbrains-marketplace-token token | JETBRAINS_MARKETPLACE_TOKEN;
+          development/kv/data/jetbrains-marketplace token | JETBRAINS_MARKETPLACE_TOKEN;
 
     - name: Download plugin from Artifactory
       shell: bash

--- a/.github/actions/upload-to-jetbrains-marketplace/action.yml
+++ b/.github/actions/upload-to-jetbrains-marketplace/action.yml
@@ -1,0 +1,56 @@
+name: Upload to JetBrains Marketplace
+description: Download the plugin zip from Repox and upload it to the JetBrains Marketplace
+author: SonarSource
+
+inputs:
+  version:
+    description: Plugin version including build number (e.g. 12.6.0.84973)
+    required: true
+  channel:
+    description: Marketplace release channel (empty means Stable)
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Get vault secrets
+      id: secrets
+      uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
+      with:
+        secrets: |
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-public-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
+          development/team/sonarlint/kv/data/jetbrains-marketplace token | JETBRAINS_MARKETPLACE_TOKEN;
+
+    - name: Download plugin from Artifactory
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        ARTIFACTORY_URL: https://repox.jfrog.io/artifactory
+        ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+      run: |
+        ARTIFACT_NAME="sonarlint-intellij-${VERSION}.zip"
+        ARTIFACT_URL="${ARTIFACTORY_URL}/sonarsource/org/sonarsource/sonarlint/intellij/sonarlint-intellij/${VERSION}/${ARTIFACT_NAME}"
+        echo "Downloading ${ARTIFACT_URL}"
+        curl -sSf -o "${ARTIFACT_NAME}" -H "Authorization: Bearer ${ARTIFACTORY_ACCESS_TOKEN}" "${ARTIFACT_URL}"
+        echo "ARTIFACT_FILE=${ARTIFACT_NAME}" >> "${GITHUB_ENV}"
+        ls -lh "${ARTIFACT_NAME}"
+
+    - name: Upload plugin to JetBrains Marketplace
+      shell: bash
+      env:
+        PLUGIN_ID: "7973"
+        CHANNEL: ${{ inputs.channel }}
+        JETBRAINS_MARKETPLACE_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).JETBRAINS_MARKETPLACE_TOKEN }}
+      run: |
+        echo "Uploading ${ARTIFACT_FILE} to JetBrains Marketplace (pluginId=${PLUGIN_ID}, channel=${CHANNEL:-Stable})"
+        CURL_ARGS=(
+          -sSf -i
+          --header "Authorization: Bearer ${JETBRAINS_MARKETPLACE_TOKEN}"
+          -F "pluginId=${PLUGIN_ID}"
+          -F "file=@${ARTIFACT_FILE}"
+        )
+        if [[ -n "${CHANNEL}" ]]; then
+          CURL_ARGS+=(-F "channel=${CHANNEL}")
+        fi
+        curl "${CURL_ARGS[@]}" https://plugins.jetbrains.com/api/updates/upload

--- a/.github/actions/upload-to-jetbrains-marketplace/action.yml
+++ b/.github/actions/upload-to-jetbrains-marketplace/action.yml
@@ -1,3 +1,5 @@
+# Downloads the promoted plugin zip from Repox and uploads it via the JetBrains Plugin Upload API:
+# https://plugins.jetbrains.com/docs/marketplace/plugin-upload.html
 name: Upload to JetBrains Marketplace
 description: Download the plugin zip from Repox and upload it to the JetBrains Marketplace
 author: SonarSource

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: sonar-release
-# Triggered by the SonarSource IDE release action (publish-github-release) via workflow_dispatch
+
 on:
   workflow_dispatch:
     inputs:
@@ -32,38 +32,9 @@ jobs:
     runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
-    env:
-      ARTIFACTORY_URL: https://repox.jfrog.io/artifactory
-      # Numeric plugin ID from https://plugins.jetbrains.com/plugin/7973-sonarlint
-      PLUGIN_ID: "7973"
     steps:
-      - name: Get vault secrets
-        id: secrets
-        uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: ./.github/actions/upload-to-jetbrains-marketplace
         with:
-          secrets: |
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-public-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
-            development/team/sonarlint/kv/data/jetbrains-marketplace token | JETBRAINS_MARKETPLACE_TOKEN;
-
-      - name: Download plugin from Artifactory
-        env:
-          VERSION: ${{ inputs.version }}
-          ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
-        run: |
-          ARTIFACT_NAME="sonarlint-intellij-${VERSION}.zip"
-          ARTIFACT_URL="${ARTIFACTORY_URL}/sonarsource/org/sonarsource/sonarlint/intellij/sonarlint-intellij/${VERSION}/${ARTIFACT_NAME}"
-          echo "Downloading ${ARTIFACT_URL}"
-          curl -sSf -o "${ARTIFACT_NAME}" -H "Authorization: Bearer ${ARTIFACTORY_ACCESS_TOKEN}" "${ARTIFACT_URL}"
-          echo "ARTIFACT_FILE=${ARTIFACT_NAME}" >> "${GITHUB_ENV}"
-          ls -lh "${ARTIFACT_NAME}"
-
-      - name: Upload plugin to JetBrains Marketplace
-        env:
-          JETBRAINS_MARKETPLACE_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).JETBRAINS_MARKETPLACE_TOKEN }}
-        run: |
-          echo "Uploading ${ARTIFACT_FILE} to JetBrains Marketplace (pluginId=${PLUGIN_ID})"
-          curl -sSf -i \
-            --header "Authorization: Bearer ${JETBRAINS_MARKETPLACE_TOKEN}" \
-            -F "pluginId=${PLUGIN_ID}" \
-            -F "file=@${ARTIFACT_FILE}" \
-            https://plugins.jetbrains.com/api/updates/upload
+          version: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
         id: secrets
         uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
         with:
-          # TODO(SLI-2267): replace the jetbrains-marketplace vault path/key once the permanent token is available
           secrets: |
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-public-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
             development/team/sonarlint/kv/data/jetbrains-marketplace token | JETBRAINS_MARKETPLACE_TOKEN;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,6 @@ jobs:
       dryRun: ${{ inputs.dryRun }}
       slackChannel: C02E6L5C01H # squad-devex-private
 
-  # Upload the promoted plugin zip to the JetBrains Marketplace via their Plugin Upload API:
-  # https://plugins.jetbrains.com/docs/marketplace/plugin-upload.html
   deploy_to_jetbrains_marketplace:
     if: ${{ !inputs.dryRun }}
     name: Deploy to JetBrains Marketplace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: sonar-release
-
+# Triggered by the SonarSource IDE release action (publish-github-release) via workflow_dispatch
 on:
   workflow_dispatch:
     inputs:
@@ -22,3 +22,49 @@ jobs:
       version: ${{ inputs.version }}
       dryRun: ${{ inputs.dryRun }}
       slackChannel: C02E6L5C01H # squad-devex-private
+
+  # Upload the promoted plugin zip to the JetBrains Marketplace via their Plugin Upload API:
+  # https://plugins.jetbrains.com/docs/marketplace/plugin-upload.html
+  deploy_to_jetbrains_marketplace:
+    if: ${{ !inputs.dryRun }}
+    name: Deploy to JetBrains Marketplace
+    needs: release
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      id-token: write
+    env:
+      ARTIFACTORY_URL: https://repox.jfrog.io/artifactory
+      # Numeric plugin ID from https://plugins.jetbrains.com/plugin/7973-sonarlint
+      PLUGIN_ID: "7973"
+    steps:
+      - name: Get vault secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@881045d830534a70ec3c7c275fa3714412c8ff6e # 3.6.1
+        with:
+          # TODO(SLI-2267): replace the jetbrains-marketplace vault path/key once the permanent token is available
+          secrets: |
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-public-reader access_token | ARTIFACTORY_ACCESS_TOKEN;
+            development/team/sonarlint/kv/data/jetbrains-marketplace token | JETBRAINS_MARKETPLACE_TOKEN;
+
+      - name: Download plugin from Artifactory
+        env:
+          VERSION: ${{ inputs.version }}
+          ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+        run: |
+          ARTIFACT_NAME="sonarlint-intellij-${VERSION}.zip"
+          ARTIFACT_URL="${ARTIFACTORY_URL}/sonarsource/org/sonarsource/sonarlint/intellij/sonarlint-intellij/${VERSION}/${ARTIFACT_NAME}"
+          echo "Downloading ${ARTIFACT_URL}"
+          curl -sSf -o "${ARTIFACT_NAME}" -H "Authorization: Bearer ${ARTIFACTORY_ACCESS_TOKEN}" "${ARTIFACT_URL}"
+          echo "ARTIFACT_FILE=${ARTIFACT_NAME}" >> "${GITHUB_ENV}"
+          ls -lh "${ARTIFACT_NAME}"
+
+      - name: Upload plugin to JetBrains Marketplace
+        env:
+          JETBRAINS_MARKETPLACE_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).JETBRAINS_MARKETPLACE_TOKEN }}
+        run: |
+          echo "Uploading ${ARTIFACT_FILE} to JetBrains Marketplace (pluginId=${PLUGIN_ID})"
+          curl -sSf -i \
+            --header "Authorization: Bearer ${JETBRAINS_MARKETPLACE_TOKEN}" \
+            -F "pluginId=${PLUGIN_ID}" \
+            -F "file=@${ARTIFACT_FILE}" \
+            https://plugins.jetbrains.com/api/updates/upload


### PR DESCRIPTION
## Summary
* Add a post-promotion job in `release.yml` that downloads the plugin zip from Repox and uploads it to the JetBrains Marketplace via the Plugin Upload API
* Leave a Vault placeholder for the JetBrains Marketplace permanent token (`development/team/sonarlint/kv/data/jetbrains-marketplace`)