### PR TITLE
SLI-2792 Do not fail service startup when JCEF is unavailable

### DIFF
--- a/src/main/java/org/sonarlint/intellij/core/BackendService.kt
+++ b/src/main/java/org/sonarlint/intellij/core/BackendService.kt
@@ -36,7 +36,6 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.project.ProjectManagerListener
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.serviceContainer.NonInjectable
-import com.intellij.ui.jcef.JBCefApp
 import java.io.IOException
 import java.net.URI
 import java.nio.file.Files
@@ -465,7 +464,7 @@ class BackendService : Disposable {
     }
 
     private fun getTelemetryConstantAttributes() =
-        TelemetryClientConstantAttributesDto("idea", "SonarLint IntelliJ", getService(SonarLintPlugin::class.java).version, getIdeVersionForTelemetry(), mapOf("intellij" to mapOf("jcefSupported" to JBCefApp.isSupported())))
+        TelemetryClientConstantAttributesDto("idea", "SonarLint IntelliJ", getService(SonarLintPlugin::class.java).version, getIdeVersionForTelemetry(), mapOf("intellij" to mapOf("jcefSupported" to JcefAvailability.isSupported())))
 
     private fun getIdeVersionForTelemetry(): String {
         var ideVersion: String

--- a/src/main/java/org/sonarlint/intellij/core/JcefAvailability.kt
+++ b/src/main/java/org/sonarlint/intellij/core/JcefAvailability.kt
@@ -1,0 +1,40 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) SonarSource Sàrl
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.core
+
+import com.intellij.ui.jcef.JBCefApp
+
+/**
+ * JCEF is used only for a telemetry attribute. From IntelliJ 2026.2 the classes live in the
+ * bundled Web Browser (JCEF) plugin and are visible only if we declare a dependency on
+ * `com.intellij.modules.jcef`. When that module is missing, [JBCefApp] must not be allowed
+ * to abort backend startup with [NoClassDefFoundError].
+ */
+object JcefAvailability {
+    fun isSupported() = isSupported { JBCefApp.isSupported() }
+
+    internal fun isSupported(check: () -> Boolean): Boolean {
+        return try {
+            check()
+        } catch (_: LinkageError) {
+            false
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin-jcef.xml
+++ b/src/main/resources/META-INF/plugin-jcef.xml
@@ -1,0 +1,29 @@
+<!--
+
+    SonarLint for IntelliJ IDEA
+    Copyright (C) SonarSource Sàrl
+    sonarlint@sonarsource.com
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+
+-->
+<!--
+    Optional fragment merged when com.intellij.modules.jcef is present.
+    Declares no extensions; exists so plugin.xml optional depends may specify config-file.
+    Bridges classpath for com.intellij.ui.jcef.* (e.g. JBCefApp) used for telemetry on IntelliJ 2026.2+.
+    The module alias exists since 2025.3.1; on older IDEs this optional dependency is skipped.
+-->
+<idea-plugin>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -65,7 +65,7 @@
 
     <change-notes><![CDATA[
       <ul>
-        <li>12.7 - Fix rule configuration panel not updating the active rules without a restart. More rules and FPs fixes for JS, extend JavaScript test rules to Bun and node:test. Improvements and fewer FPs in secrets. New Pytest/Pydantic rules, bugfixes for Python. </li>
+        <li>12.7 - Fix service startup failure on IntelliJ 2026.2 when the JCEF module is unavailable. Fix rule configuration panel not updating the active rules without a restart. More rules and FPs fixes for JS, extend JavaScript test rules to Bun and node:test. Improvements and fewer FPs in secrets. New Pytest/Pydantic rules, bugfixes for Python. </li>
         <li>12.6 - Faster issue highlighting on large files. 5 new rules for Python testing frameworks. Fewer FPs for PHP and secrets detection.</li>
         <li>12.5 - Add support for Shell and Azure Pipelines. Migrate Security Hotspots to issues for Kotlin, IaC and Ruby. Support of Java 26. 12 new rules for JS/TS testing frameworks and Vue. 5 new rules for Python.</li>
         <li>12.4 - Fixed IDE UI freezes and duplicate findings in Rider. 3 new JUnit 5 rules for Java. New security and accessibility rules for HTML. Improved Python analysis. Fewer FPs for Java, PHP, Go, and HTML.</li>
@@ -239,6 +239,7 @@
   <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
        on how to target different products -->
   <depends>com.intellij.modules.lang</depends>
+    <depends optional="true" config-file="plugin-jcef.xml">com.intellij.modules.jcef</depends>
     <depends optional="true" config-file="plugin-git.xml">Git4Idea</depends>
     <depends optional="true" config-file="plugin-go.xml">org.jetbrains.plugins.go</depends>
     <depends optional="true" config-file="plugin-plsql.xml">com.intellij.database</depends>

--- a/src/test/java/org/sonarlint/intellij/core/JcefAvailabilityTests.kt
+++ b/src/test/java/org/sonarlint/intellij/core/JcefAvailabilityTests.kt
@@ -1,0 +1,44 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) SonarSource Sàrl
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class JcefAvailabilityTests {
+
+    @Test
+    fun should_return_true_when_jcef_is_supported() {
+        assertThat(JcefAvailability.isSupported { true }).isTrue()
+    }
+
+    @Test
+    fun should_return_false_when_jcef_is_not_supported() {
+        assertThat(JcefAvailability.isSupported { false }).isFalse()
+    }
+
+    @Test
+    fun should_return_false_when_jcef_class_is_missing() {
+        assertThat(
+            JcefAvailability.isSupported { throw NoClassDefFoundError("com/intellij/ui/jcef/JBCefApp") }
+        ).isFalse()
+    }
+
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of [SLI-2792](https://sonarsource.atlassian.net/browse/SLI-2792)

## Summary

IntelliJ 2026.2 moved JCEF out of the core platform into the bundled Web Browser (JCEF) plugin (`com.intellij.modules.jcef`, JetBrains IJPL-246446). `BackendService` called `JBCefApp.isSupported()` unconditionally while collecting telemetry, and the plugin did not declare a dependency on that module. When `JBCefApp` is not visible to our classloader, startup fails with:

`NoClassDefFoundError: com/intellij/ui/jcef/JBCefApp`

cascading into “Cannot start the SonarQube for IDE service”.

JCEF is telemetry-only; no product feature depends on it.

## Changes

- Isolate the JCEF probe in `JcefAvailability` and treat `LinkageError` (including `NoClassDefFoundError`) as “not supported”, so a missing class cannot abort backend startup.
- Declare an **optional** dependency on `com.intellij.modules.jcef` so that when the module is present (IntelliJ 2026.2 with Web Browser (JCEF) enabled), it is on our classloader and telemetry stays accurate. The dependency is optional so:
  - the plugin still loads if the user disables JCEF
  - we remain compatible with IDEs before 2025.3.1, where the module alias does not exist (a required dependency would not)

## References

- Community report: https://community.sonarsource.com/t/intellij-idea-2026-2-and-12-6-0-84973-compatibility-issue/186506
- Similar plugin fix (required dep, they actually use JCEF): https://github.com/asciidoctor/asciidoctor-intellij-plugin/pull/2081

## Testing

- `./gradlew :test --tests org.sonarlint.intellij.core.JcefAvailabilityTests` — passed
- `./gradlew license` — passed
- Unit tests cover supported / unsupported / missing-class (`NoClassDefFoundError`) cases
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd628597-ff90-422f-8472-8451831efd38?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd628597-ff90-422f-8472-8451831efd38&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[SLI-2792]: https://sonarsource.atlassian.net/browse/SLI-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ