### PR TITLE
SLI-2804 Avoid freeze when rendering taint vulnerabilities

### DIFF
--- a/src/main/java/org/sonarlint/intellij/ui/nodes/AbstractNode.java
+++ b/src/main/java/org/sonarlint/intellij/ui/nodes/AbstractNode.java
@@ -20,7 +20,6 @@
 package org.sonarlint.intellij.ui.nodes;
 
 import com.intellij.openapi.editor.RangeMarker;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -89,7 +88,7 @@ public abstract class AbstractNode extends DefaultMutableTreeNode {
     }
   }
 
-  public String formatRangeMarker(@Nullable VirtualFile file, @Nullable RangeMarker rangeMarker) {
+  public static String formatRangeMarker(@Nullable VirtualFile file, @Nullable RangeMarker rangeMarker) {
     if (rangeMarker == null) {
       return "(0, 0) ";
     }
@@ -98,13 +97,9 @@ public abstract class AbstractNode extends DefaultMutableTreeNode {
       return UNKNOWN_RANGE_COORDINATES;
     }
 
-    var cachedDocument = FileDocumentManager.getInstance().getCachedDocument(file);
-    if (cachedDocument == null) {
-      return UNKNOWN_RANGE_COORDINATES;
-    }
-
-    var line = cachedDocument.getLineNumber(rangeMarker.getStartOffset());
-    var offset = rangeMarker.getStartOffset() - cachedDocument.getLineStartOffset(line);
+    var document = rangeMarker.getDocument();
+    var line = document.getLineNumber(rangeMarker.getStartOffset());
+    var offset = rangeMarker.getStartOffset() - document.getLineStartOffset(line);
     return String.format("(%d, %d) ", line + 1, offset);
   }
 

--- a/src/main/java/org/sonarlint/intellij/ui/vulnerabilities/tree/render/LocalTaintVulnerabilityRenderer.kt
+++ b/src/main/java/org/sonarlint/intellij/ui/vulnerabilities/tree/render/LocalTaintVulnerabilityRenderer.kt
@@ -23,17 +23,14 @@ import com.intellij.openapi.util.text.StringUtil
 import com.intellij.ui.SimpleTextAttributes
 import java.util.Locale
 import javax.swing.Icon
-import org.sonarlint.intellij.common.ui.ReadActionUtils.Companion.computeReadActionSafely
 import org.sonarlint.intellij.finding.issue.vulnerabilities.LocalTaintVulnerability
 import org.sonarlint.intellij.ui.icons.DisplayedStatus
 import org.sonarlint.intellij.ui.icons.FindingIconBuilder
 import org.sonarlint.intellij.ui.icons.SonarLintIcons
+import org.sonarlint.intellij.ui.nodes.AbstractNode
 import org.sonarlint.intellij.ui.tree.NodeRenderer
 import org.sonarlint.intellij.ui.tree.TreeCellRenderer
 import org.sonarlint.intellij.util.DateUtils
-import org.sonarlint.intellij.util.computeOnPooledThread
-
-private const val UNKNOWN_COORDINATES = "(-, -) "
 
 object LocalTaintVulnerabilityRenderer : NodeRenderer<LocalTaintVulnerability> {
 
@@ -87,20 +84,8 @@ object LocalTaintVulnerabilityRenderer : NodeRenderer<LocalTaintVulnerability> {
     }
 
     private fun issueCoordinates(issue: LocalTaintVulnerability): String {
-        val range = issue.rangeMarker() ?: return "(0, 0) "
-        if (!issue.isValid()) {
-            return UNKNOWN_COORDINATES
-        }
-        val file = issue.file() ?: return UNKNOWN_COORDINATES
-
-        return computeOnPooledThread("Calculate Issue Coordinates") {
-            computeReadActionSafely(file) {
-                val doc = range.document
-                val line = doc.getLineNumber(range.startOffset)
-                val offset = range.startOffset - doc.getLineStartOffset(line)
-                "(%d, %d) ".format(line + 1, offset)
-            }
-        } ?: UNKNOWN_COORDINATES
+        // Paint runs on the EDT. Use the in-memory range-marker document; do not load or block.
+        return AbstractNode.formatRangeMarker(issue.file(), issue.rangeMarker())
     }
 
 }

--- a/src/main/java/org/sonarlint/intellij/ui/vulnerabilities/tree/render/LocationRenderer.kt
+++ b/src/main/java/org/sonarlint/intellij/ui/vulnerabilities/tree/render/LocationRenderer.kt
@@ -21,9 +21,9 @@ package org.sonarlint.intellij.ui.vulnerabilities.tree.render
 
 import com.intellij.ui.SimpleTextAttributes
 import com.intellij.util.ui.JBUI
-import org.sonarlint.intellij.common.ui.ReadActionUtils.Companion.computeReadActionSafely
 import org.sonarlint.intellij.finding.FragmentLocation
 import org.sonarlint.intellij.finding.Location
+import org.sonarlint.intellij.ui.nodes.AbstractNode
 import org.sonarlint.intellij.ui.tree.NodeRenderer
 import org.sonarlint.intellij.ui.tree.TreeCellRenderer
 
@@ -48,17 +48,9 @@ object LocationRenderer : NodeRenderer<FragmentLocation> {
 
     private fun issueCoordinates(location: Location): String {
         if (!location.exists()) {
-            return "(-, -) "
+            return AbstractNode.UNKNOWN_RANGE_COORDINATES
         }
-
-        return location.file?.let {
-            computeReadActionSafely(it) {
-                val rangeMarker = location.range!!
-                val doc = rangeMarker.document
-                val line = doc.getLineNumber(rangeMarker.startOffset)
-                val offset = rangeMarker.startOffset - doc.getLineStartOffset(line)
-                "(%d, %d) ".format(line + 1, offset)
-            }
-        } ?: "(-, -) "
+        // Paint runs on the EDT. Use the in-memory range-marker document; do not load or block.
+        return AbstractNode.formatRangeMarker(location.file, location.range)
     }
 }

--- a/src/test/java/org/sonarlint/intellij/ui/nodes/PrimaryLocationNodeTests.java
+++ b/src/test/java/org/sonarlint/intellij/ui/nodes/PrimaryLocationNodeTests.java
@@ -33,8 +33,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class PrimaryLocationNodeTests extends AbstractSonarLintLightTests {
+  private final RangeMarker range = mock(RangeMarker.class);
   private PrimaryLocationNode node;
-  private RangeMarker range = mock(RangeMarker.class);
 
   @BeforeEach
   void prepare() {
@@ -43,6 +43,7 @@ class PrimaryLocationNodeTests extends AbstractSonarLintLightTests {
     when(range.isValid()).thenReturn(true);
     when(range.getStartOffset()).thenReturn(3);
     when(range.getEndOffset()).thenReturn(10);
+    when(range.getDocument()).thenReturn(myFixture.getDocument(myFixture.getFile()));
   }
 
   @Test

--- a/src/test/java/org/sonarlint/intellij/ui/vulnerabilities/tree/render/LocalTaintVulnerabilityRendererTests.kt
+++ b/src/test/java/org/sonarlint/intellij/ui/vulnerabilities/tree/render/LocalTaintVulnerabilityRendererTests.kt
@@ -1,0 +1,99 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) SonarSource Sàrl
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.ui.vulnerabilities.tree.render
+
+import com.intellij.openapi.editor.RangeMarker
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.SimpleTextAttributes
+import java.time.Instant
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.sonarlint.intellij.AbstractSonarLintLightTests
+import org.sonarlint.intellij.finding.Location
+import org.sonarlint.intellij.finding.issue.vulnerabilities.LocalTaintVulnerability
+import org.sonarlint.intellij.ui.tree.TreeCellRenderer
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.TaintVulnerabilityDto
+
+class LocalTaintVulnerabilityRendererTests : AbstractSonarLintLightTests() {
+    private lateinit var range: RangeMarker
+
+    @BeforeEach
+    fun prepare() {
+        myFixture.configureByText("file.txt", "my document test")
+        range = myFixture.getDocument(myFixture.file).createRangeMarker(3, 10)
+    }
+
+    @Test
+    fun `renders coordinates from the range marker document`() {
+        val renderer = mock<TreeCellRenderer>()
+
+        LocalTaintVulnerabilityRenderer.render(renderer, aTaint(myFixture.file.virtualFile, range))
+
+        verify(renderer).append("(1, 3) ", SimpleTextAttributes.GRAY_ATTRIBUTES)
+        verify(renderer).append("SQL injection", SimpleTextAttributes.GRAY_ATTRIBUTES)
+    }
+
+    @Test
+    fun `renders coordinates when the file is not open in an editor`() {
+        val file = mock<VirtualFile>()
+        whenever(file.isValid).thenReturn(true)
+        val renderer = mock<TreeCellRenderer>()
+
+        LocalTaintVulnerabilityRenderer.render(renderer, aTaint(file, range))
+
+        verify(renderer).append("(1, 3) ", SimpleTextAttributes.GRAY_ATTRIBUTES)
+    }
+
+    @Test
+    fun `renders unknown coordinates when the file is missing`() {
+        val renderer = mock<TreeCellRenderer>()
+
+        LocalTaintVulnerabilityRenderer.render(renderer, aTaint(null, range))
+
+        verify(renderer).append("(-, -) ", SimpleTextAttributes.GRAY_ATTRIBUTES)
+    }
+
+    @Test
+    fun `renders zero coordinates when the range is missing`() {
+        val renderer = mock<TreeCellRenderer>()
+
+        LocalTaintVulnerabilityRenderer.render(renderer, aTaint(myFixture.file.virtualFile, null))
+
+        verify(renderer).append("(0, 0) ", SimpleTextAttributes.GRAY_ATTRIBUTES)
+    }
+
+    private fun aTaint(file: VirtualFile?, rangeMarker: RangeMarker?): LocalTaintVulnerability {
+        val dto = Mockito.mock(TaintVulnerabilityDto::class.java, Mockito.RETURNS_DEEP_STUBS)
+        whenever(dto.message).thenReturn("SQL injection")
+        whenever(dto.introductionDate).thenReturn(Instant.EPOCH)
+        whenever(dto.isAiCodeFixable).thenReturn(false)
+        return LocalTaintVulnerability(
+            null,
+            Location(file, rangeMarker, "SQL injection", null, null),
+            emptyList(),
+            dto,
+            true
+        )
+    }
+}

--- a/src/test/java/org/sonarlint/intellij/ui/vulnerabilities/tree/render/LocationRendererTests.kt
+++ b/src/test/java/org/sonarlint/intellij/ui/vulnerabilities/tree/render/LocationRendererTests.kt
@@ -1,0 +1,67 @@
+/*
+ * SonarLint for IntelliJ IDEA
+ * Copyright (C) SonarSource Sàrl
+ * sonarlint@sonarsource.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonarlint.intellij.ui.vulnerabilities.tree.render
+
+import com.intellij.openapi.editor.RangeMarker
+import com.intellij.ui.SimpleTextAttributes
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.sonarlint.intellij.AbstractSonarLintLightTests
+import org.sonarlint.intellij.finding.Flow
+import org.sonarlint.intellij.finding.FragmentLocation
+import org.sonarlint.intellij.finding.Location
+import org.sonarlint.intellij.ui.tree.TreeCellRenderer
+
+class LocationRendererTests : AbstractSonarLintLightTests() {
+    private lateinit var range: RangeMarker
+
+    @BeforeEach
+    fun prepare() {
+        myFixture.configureByText("file.txt", "my document test")
+        range = myFixture.getDocument(myFixture.file).createRangeMarker(3, 10)
+    }
+
+    @Test
+    fun `renders coordinates from the range marker document`() {
+        val renderer = mock<TreeCellRenderer>()
+
+        LocationRenderer.render(renderer, aFragment(Location(myFixture.file.virtualFile, range, "sink", null, null)))
+
+        verify(renderer).append("(1, 3) ", SimpleTextAttributes.GRAY_ATTRIBUTES)
+        verify(renderer).append("sink", SimpleTextAttributes.REGULAR_ATTRIBUTES)
+    }
+
+    @Test
+    fun `renders unknown coordinates when the location does not exist`() {
+        val renderer = mock<TreeCellRenderer>()
+
+        LocationRenderer.render(renderer, aFragment(Location(null, range, "sink", null, null)))
+
+        verify(renderer).append("(-, -) ", SimpleTextAttributes.GRAY_ATTRIBUTES)
+        verify(renderer).append(" (unreachable in local code)", SimpleTextAttributes.GRAYED_SMALL_ATTRIBUTES)
+    }
+
+    private fun aFragment(location: Location): FragmentLocation {
+        val flow = Flow(1, listOf(location))
+        return flow.crossFileFlowFragments[0].locations[0]
+    }
+}


### PR DESCRIPTION
----
## Summary by Gitar

- **UI rendering:**
    - Avoid freezes during taint vulnerability rendering by retrieving document from `RangeMarker` directly in `AbstractNode.formatRangeMarker`
    - Remove cached document lookup via `FileDocumentManager` and avoid read actions on the EDT
- **Tests:**
    - Add `LocalTaintVulnerabilityRendererTests` and `LocationRendererTests` to cover coordinate rendering scenarios

<sub>This will update automatically on new commits.</sub>