### PR TITLE
PREQ-8007 Disable PyPI package-cache refresh in UI-test IDE

### DIFF
--- a/its/build.gradle.kts
+++ b/its/build.gradle.kts
@@ -165,6 +165,13 @@ val runIdeForUiTests by intellijPlatformTesting.runIde.registering {
                     into(sandboxPluginsDirectory)
                 }
             }
+            // UI-test IDE is not unit-test mode, so the bundled Python plugin refreshes
+            // its PyPI package cache on startup. ITs never use that index; disable it so
+            // the sandbox does not contact pypi.org.
+            copy {
+                from(layout.projectDirectory.dir("idea-config"))
+                into(sandboxConfigDirectory)
+            }
         }
     }
 

--- a/its/idea-config/options/packages.xml
+++ b/its/idea-config/options/packages.xml
@@ -1,0 +1,5 @@
+<application>
+  <component name="PyPackageService">
+    <option name="PYPI_REMOVED" value="true" />
+  </component>
+</application>


### PR DESCRIPTION
## Summary
- PyCharm / CLion UI tests fail because the **real** UI-test IDE (not unit-test mode) lets the bundled Python plugin refresh its PyPI package cache on startup. That hits `pypi.org` / `www.python.org`. `config-pip` cannot stop it: the IDE does not read `pip.conf` ([run 31687109338](https://github.com/SonarSource/sonarlint-intellij/actions/runs/31687109338)).
- Seed the `runIdeForUiTests` sandbox with JetBrains `PyPackageService.PYPI_REMOVED=true` (`packages.xml`) so that cache refresh is skipped. ITs do not use the package index.
- IntelliJ / PhpStorm / GoLand / CLion 2024 were already green; this targets PyCharm Community, PyCharm Professional, and CLion 2025.

Jira: [PREQ-8007](https://sonarsource.atlassian.net/browse/PREQ-8007)

## Test plan
- [ ] CI ITs: `PC-2024.2`, `PY-2024.2`, `CL-2025.3.2` pass (`should_analyze_python` / CLion 2025 `should_analyze_cpp`)
- [ ] Confirm IDE logs no longer show `PyPackagesUpdater` / PKIX failures against pypi.org
- [ ] Other flavor ITs (Idea, PhpStorm, GoLand, CLion 2024) still pass

[PREQ-8007]: https://sonarsource.atlassian.net/browse/PREQ-8007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ