### PR TITLE
SLI-2837 Avoid logging Marketplace response headers

### DIFF
--- a/.github/actions/upload-to-jetbrains-marketplace/action.yml
+++ b/.github/actions/upload-to-jetbrains-marketplace/action.yml
@@ -47,7 +47,7 @@ runs:
       run: |
         echo "Uploading ${ARTIFACT_FILE} to JetBrains Marketplace (pluginId=${PLUGIN_ID}, channel=${CHANNEL:-Stable})"
         CURL_ARGS=(
-          -sSf -i
+          -sSf
           --header "Authorization: Bearer ${JETBRAINS_MARKETPLACE_TOKEN}"
           -F "pluginId=${PLUGIN_ID}"
           -F "file=@${ARTIFACT_FILE}"


### PR DESCRIPTION
## Summary
* Drop curl \`-i\` from the JetBrains Marketplace upload action so response headers (including AWS ALB \`Set-Cookie\`) are not written to CI logs
* Keep \`-sSf\` so the JSON response body is still shown on success and failures still fail the job