### PR TITLE
SLI-2844 Reflect new minimum Node.js version 22.12

### DIFF
--- a/src/main/java/org/sonarlint/intellij/config/global/SonarLintGlobalOptionsPanel.java
+++ b/src/main/java/org/sonarlint/intellij/config/global/SonarLintGlobalOptionsPanel.java
@@ -119,7 +119,7 @@ public class SonarLintGlobalOptionsPanel implements ConfigurationPanel<SonarLint
         WEST, GridBagConstraints.HORIZONTAL, JBUI.emptyInsets(), 0, 0));
     }
 
-    var label = new JLabel("Node.js path (20.12 minimum): ");
+    var label = new JLabel("Node.js path (22.12 minimum): ");
     label.setToolTipText(NODE_JS_TOOLTIP);
     optionsPanel.add(label, new GridBagConstraints(0, gridy, 1, 1, 0.0, 0.0,
       WEST, GridBagConstraints.HORIZONTAL, JBUI.emptyInsets(), 0, 0));

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -65,6 +65,7 @@
 
     <change-notes><![CDATA[
       <ul>
+        <li>12.8 - Drop support for Node.js 20, the minimum version is now 22.12.</li>
         <li>12.7 - Fix service startup failure on IntelliJ 2026.2 when the JCEF module is unavailable. Fix rule configuration panel not updating the active rules without a restart. More rules and FPs fixes for JS, extend JavaScript test rules to Bun and node:test. Improvements and fewer FPs in secrets. New Pytest/Pydantic rules, bugfixes for Python. </li>
         <li>12.6 - Faster issue highlighting on large files. 5 new rules for Python testing frameworks. Fewer FPs for PHP and secrets detection.</li>
         <li>12.5 - Add support for Shell and Azure Pipelines. Migrate Security Hotspots to issues for Kotlin, IaC and Ruby. Support of Java 26. 12 new rules for JS/TS testing frameworks and Vue. 5 new rules for Python.</li>


### PR DESCRIPTION
Part of DEX-16

----
## Summary by Gitar

- **Documentation:**
    - Updated Node.js minimum version reference to `22.12` in the global options panel label and plugin change notes.

<sub>This will update automatically on new commits.</sub>