### PR TITLE
[CONTENT-3798] README update for marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,37 @@
-SonarQube for IntelliJ Plugin
-=========================
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://assets-eu-01.kc-usercontent.com/ef593040-b591-0198-9506-ed88b30bc023/a23fc7ba-23f0-489a-829d-ed88c0748521/Sonar_Logo_Dark%20Backgrounds.svg">
+    <img src="https://assets-eu-01.kc-usercontent.com/ef593040-b591-0198-9506-ed88b30bc023/82c13eba-d95c-4bb8-8007-7ce77c14e043/Sonar_Logo_Light%20Backgrounds.svg" alt="Sonar logo" width="400">
+  </picture>
+</p>
+
+# SonarQube for IntelliJ
+
+<p>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://assets-eu-01.kc-usercontent.com/ef593040-b591-0198-9506-ed88b30bc023/7934b7e0-d989-42aa-9c75-73af00b948b7/SQ_Logo_IDE_Dark%20Backgrounds.svg">
+    <img src="https://assets-eu-01.kc-usercontent.com/ef593040-b591-0198-9506-ed88b30bc023/b839fc43-d33c-44b5-9e14-f9dee4e9a047/SQ_Logo_IDE_Light%20Backgrounds.png" alt="SonarQube for IDE logo" width="400">
+  </picture>
+</p>
 
 [![Build Status](https://github.com/SonarSource/sonarlint-intellij/actions/workflows/build.yml/badge.svg)](https://github.com/SonarSource/sonarlint-intellij/actions/workflows/build.yml?query=branch%3Amaster)
 [![Quality Gate](https://next.sonarqube.com/sonarqube/api/project_badges/measure?project=org.sonarsource.sonarlint.intellij%3Asonarlint-intellij&metric=alert_status)](https://next.sonarqube.com/sonarqube/dashboard?id=org.sonarsource.sonarlint.intellij%3Asonarlint-intellij)
+[![JetBrains Plugin](https://img.shields.io/jetbrains/plugin/v/7973-sonarlint)](https://plugins.jetbrains.com/plugin/7973-sonarqube-for-ide)
+[![GitHub stars](https://img.shields.io/github/stars/SonarSource/sonarlint-intellij?style=flat)](https://github.com/SonarSource/sonarlint-intellij)
+[![License](https://img.shields.io/badge/license-LGPL--3.0-blue)](#license)
+[![Community forum](https://img.shields.io/badge/community-forum-blue)](https://community.sonarsource.com/c/sl/11)
 
-SonarQube for IDE is an IDE extension that helps you detect and fix quality issues, ensuring you
-deliver [integrated code quality and security](https://www.sonarsource.com/solutions/for-developers/).
-Like a spell checker, SonarQube for IntelliJ squiggles flaws so they can be fixed before committing code.
+SonarQube for IntelliJ analyzes code as you edit in JetBrains IDEs, highlighting code quality and security findings where they can be fixed before commit.
+
+This repository contains the source for the IDE plugin. It applies the same analysis to code written by developers and AI assistants, and it can connect to SonarQube Server or SonarQube Cloud to share team rules and settings.
+
+What it does
+------------
+
+- Detects code quality and security issues as you edit.
+- Highlights issues in the editor and explains why they matter.
+- Supports connected analysis with [SonarQube Server](https://www.sonarsource.com/products/sonarqube/server/) and [SonarQube Cloud](https://www.sonarsource.com/products/sonarqube/cloud/).
+- Helps verify developer-written and AI-generated code before commit.
 
 Useful links
 ------------


### PR DESCRIPTION
## Summary

This PR makes a focused README marketing update:

- adds responsive Sonar and SonarQube for IDE logos for GitHub light and dark modes
- adds a clear SonarQube for IntelliJ heading and useful plugin/repository/community badges
- refreshes the opening description and adds a concise summary of the plugin's role

The repository's existing links, build instructions, development guidance, contribution policy, and licensing are otherwise preserved.

## Review guidance

These changes were prepared automatically using the [shared README guidelines](https://github.com/SonarSource/sonar-readme-updates/blob/readme-updates/README-guidelines.md).

Please review the diff carefully for repository-specific and product-marketing accuracy, verify the logos in GitHub light and dark modes, and confirm that all required checks pass.

## Merge ownership

If the changes are accurate and all required checks pass, please have a CODEOWNER merge this PR when you are ready. The rollout author will not merge it because the repository owners are best placed to assess repository-specific checks and any build impact.

If a check fails or a correction is needed, please leave the PR unmerged and add a review comment.

## Validation

- reconciled with `master` at `9ede0d43f2927b667af60cdbc5e947becc0542d0`
- confirmed that all content from `Useful links` onward remains unchanged
- verified the new links and CDN-hosted light/dark logo URLs
- deliberately excluded the earlier proposed build, test, contribution, and licence rewrites

This is a documentation-only change and does not modify runtime code.

## Tracking

Jira epic: [CONTENT-3798](https://sonarsource.atlassian.net/browse/CONTENT-3798)


[CONTENT-3798]: https://sonarsource.atlassian.net/browse/CONTENT-3798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ