### PR TITLE
SLI-2812 Avoid OOB while refreshing findings

### DIFF
--- a/src/main/java/org/sonarlint/intellij/actions/SonarLintToolWindow.java
+++ b/src/main/java/org/sonarlint/intellij/actions/SonarLintToolWindow.java
@@ -48,7 +48,6 @@ import static org.sonarlint.intellij.ui.ToolWindowConstants.CURRENT_FILE_TAB_TIT
 import static org.sonarlint.intellij.ui.ToolWindowConstants.LOG_TAB_TITLE;
 import static org.sonarlint.intellij.ui.ToolWindowConstants.TOOL_WINDOW_ID;
 import static org.sonarlint.intellij.ui.UiUtils.runOnUiThread;
-import static org.sonarlint.intellij.util.ThreadUtilsKt.runOnPooledThread;
 
 @Service(Service.Level.PROJECT)
 public final class SonarLintToolWindow implements ContentManagerListener, ProjectBindingListener {
@@ -131,7 +130,7 @@ public final class SonarLintToolWindow implements ContentManagerListener, Projec
         for (var tabTitle : reportTabManager.getOpenReportTabs()) {
           var content = contentManager.findContent(tabTitle);
           if (content != null && content.getComponent() instanceof ReportPanel reportPanel) {
-            runOnPooledThread(project, reportPanel::refreshView);
+            reportPanel.refreshView();
           }
         }
       });

--- a/src/main/java/org/sonarlint/intellij/ui/report/ReportTreeManager.kt
+++ b/src/main/java/org/sonarlint/intellij/ui/report/ReportTreeManager.kt
@@ -19,6 +19,7 @@
  */
 package org.sonarlint.intellij.ui.report
 
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.project.Project
 import com.intellij.ui.treeStructure.Tree
 import com.intellij.util.ui.tree.TreeUtil
@@ -31,6 +32,7 @@ import org.sonarlint.intellij.editor.EditorDecorator
 import org.sonarlint.intellij.finding.issue.vulnerabilities.LocalTaintVulnerability
 import org.sonarlint.intellij.ui.FindingDetailsPanel
 import org.sonarlint.intellij.ui.UiUtils.Companion.runOnUiThread
+import org.sonarlint.intellij.ui.UiUtils.Companion.runOnUiThreadAndWait
 import org.sonarlint.intellij.ui.nodes.IssueNode
 import org.sonarlint.intellij.ui.nodes.LiveSecurityHotspotNode
 import org.sonarlint.intellij.ui.report.tree.ReportIssueTreeModelBuilder
@@ -168,14 +170,21 @@ class ReportTreeManager(
      * This should be called before updating tree models.
      */
     fun takeTreeStateSnapshot(): Map<Tree, Set<String>> {
-        return mapOf(
-            issuesTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(issuesTree),
-            oldIssuesTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(oldIssuesTree),
-            securityHotspotsTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(securityHotspotsTree),
-            oldSecurityHotspotsTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(oldSecurityHotspotsTree),
-            taintsTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(taintsTree),
-            oldTaintsTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(oldTaintsTree)
-        )
+        // Swing tree/model state must only be read on the EDT: this can be called from a
+        // background thread (e.g. ReportPanel.refreshView via runOnPooledThread), and reading it
+        // there races with the EDT-queued tree model mutations, which can throw ArrayIndexOutOfBoundsException.
+        var snapshot: Map<Tree, Set<String>> = emptyMap()
+        runOnUiThreadAndWait(project, ModalityState.defaultModalityState()) {
+            snapshot = mapOf(
+                issuesTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(issuesTree),
+                oldIssuesTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(oldIssuesTree),
+                securityHotspotsTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(securityHotspotsTree),
+                oldSecurityHotspotsTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(oldSecurityHotspotsTree),
+                taintsTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(taintsTree),
+                oldTaintsTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(oldTaintsTree)
+            )
+        }
+        return snapshot
     }
     
     /**

--- a/src/main/java/org/sonarlint/intellij/ui/report/ReportTreeManager.kt
+++ b/src/main/java/org/sonarlint/intellij/ui/report/ReportTreeManager.kt
@@ -170,11 +170,12 @@ class ReportTreeManager(
      * This should be called before updating tree models.
      */
     fun takeTreeStateSnapshot(): Map<Tree, Set<String>> {
-        // Swing tree/model state must only be read on the EDT: this can be called from a
-        // background thread (e.g. ReportPanel.refreshView via runOnPooledThread), and reading it
-        // there races with the EDT-queued tree model mutations, which can throw ArrayIndexOutOfBoundsException.
+        // Swing tree/model state must only be read on the EDT: reading it off-EDT can race with
+        // EDT-queued tree model mutations and throw ArrayIndexOutOfBoundsException. All current
+        // callers already run on the EDT, but this guarantees it regardless of caller thread.
         var snapshot: Map<Tree, Set<String>> = emptyMap()
-        runOnUiThreadAndWait(project, ModalityState.defaultModalityState()) {
+        // ModalityState.any() avoids stalling a caller thread behind an open modal dialog for this read-only snapshot.
+        runOnUiThreadAndWait(project, ModalityState.any()) {
             snapshot = mapOf(
                 issuesTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(issuesTree),
                 oldIssuesTree to TreeExpansionStateManager.takeFileNodeExpansionStateSnapshot(oldIssuesTree),


### PR DESCRIPTION
## Summary
Fixes an `ArrayIndexOutOfBoundsException` when refreshing the Report tab findings tree.

`ReportTreeManager.takeTreeStateSnapshot()` read live Swing tree state from a background thread while tree model mutations were queued asynchronously on the EDT, causing a race. The snapshot is now taken synchronously on the EDT.

## Test plan
- [x] `./gradlew compileKotlin compileTestKotlin`
- [x] `./gradlew -x :its:check -x :buildPlugin -x :buildPluginBlockmap -x :cyclonedxBom check` (only pre-existing, unrelated environment failures)